### PR TITLE
Refactor attacks

### DIFF
--- a/addonsdb.cpp
+++ b/addonsdb.cpp
@@ -133,6 +133,8 @@ int AddOnsDb::incrSize()
 {
 	int newSize = size + 5;
 	AddOns** newTable = new AddOns* [newSize];
+	for (int i {0}; i < newSize; ++i)
+		newTable[i] = nullptr;
 
 	for (int i {0}; i < size; ++i)
 		copy(newTable[i], table[i]);

--- a/addonsdb.cpp
+++ b/addonsdb.cpp
@@ -6,58 +6,50 @@ Class:      CS202
 Term:	    Fall 2020
 
 This file contains the implementations for class AddOnsDb.
-Some functions were created for an idea that never manifested or changed and therefore
-was not used in main program.  Information below for functions.
 */
 
 #include "addonsdb.h"
 
 // default constructor creates a table and initialize everything to 0
 AddOnsDb::AddOnsDb() : table(0), size(5)
-{ // change back to 5 after figure out copy messup in incrSize function
-	table = new Attacks *[size];
-	init(table, table, size);
+{
+	table = new AddOns* [size];
+	for (int i {0}; i < size; ++i)
+		table[i] {nullptr};
 }
 
 // copy constructor
-AddOnsDb::AddOnsDb(const AddOnsDb &source) : table(0), size(source.size)
+AddOnsDb::AddOnsDb(const AddOnsDb & source) : table(0), size(source.size)
 {
-	table = new Attacks *[size];
-	copy(table, table, source.table);
+	table = new AddOns* [size];
+	for (int i {0}; i < size; ++i)
+		copy(table[i], source[i]);
 }
 
 // destructor
 AddOnsDb::~AddOnsDb()
 {
-	destroy(table);
+	for (int i {0}; i < size; ++i)
+		destroy(table[i]);
 	delete[] table;
 	table = NULL;
 }
 
-// recursively initialize each array index to 0, can be used with any table not just this object
-void AddOnsDb::init(Attacks **arr, Attacks **tbl, int s)
-{
-	if (arr != tbl + s)
-	{
-		*arr = NULL;
-		init(++arr, tbl, s);
-	}
-}
-
-// recursively copy all from source pointer
-void AddOnsDb::copy(Attacks *&ptr, Attacks *srcPtr)
+// recursively copy all of list from source pointer
+void AddOnsDb::copy(AddOns* & ptr, AddOns* srcPtr)
 {
 	ptr = NULL;
 	if (srcPtr)
 	{
 		if (typeid(*srcPtr) == typeid(Items))
 		{
-			Items *item = dynamic_cast<Items *>(srcPtr);
+			Items *item = dynamic_cast<Items*>(srcPtr);
 			ptr = new Items(*item);
 		}
 		else
 		{
-			ptr = new Attacks(*srcPtr);
+			Attacks *attack = dynamic_cast<Attacks*>(srcPtr);
+			ptr = new Attacks(*attack);
 		}
 		copy(ptr->nextLink(), srcPtr->nextLink());
 		if (ptr->nextLink())
@@ -67,35 +59,15 @@ void AddOnsDb::copy(Attacks *&ptr, Attacks *srcPtr)
 	}
 }
 
-// recursively copy all from source table
-void AddOnsDb::copy(Attacks **arr, Attacks **dstTbl, Attacks **srcTbl)
-{
-	if (arr != dstTbl + size)
-	{
-		copy(*arr, *srcTbl);
-		copy(++arr, dstTbl, ++srcTbl);
-	}
-}
-
-// recursively destroy all from pointer
-void AddOnsDb::destroy(Attacks *&ptr)
+// recursively destroy all of list from pointer
+void AddOnsDb::destroy(AddOns* & ptr)
 {
 	if (ptr)
 	{
-		Attacks *temp = ptr;
+		AddOns* temp = ptr;
 		ptr = ptr->nextLink();
 		delete temp;
 		destroy(ptr);
-	}
-}
-
-// recursively destroy all from table
-void AddOnsDb::destroy(Attacks **arr)
-{
-	if (arr != table + size)
-	{
-		destroy(*arr);
-		destroy(++arr);
 	}
 }
 

--- a/addonsdb.h
+++ b/addonsdb.h
@@ -26,14 +26,11 @@ using namespace std;
 class AddOnsDb
 {
 private:
-	Attacks **table;
+	AddOns** table;
 	int size;
 
-	void init(Attacks **, Attacks **, int);				  // initialize table to 0, array recursion
-	void copy(Attacks *&, Attacks *);					  // copy all table, list recursion
-	void copy(Attacks **, Attacks **, Attacks **);		  // copy all table, array recursion
-	void destroy(Attacks *&);							  // destroy everything, list recursion
-	void destroy(Attacks **);							  // destroy everything, array recursion
+	void copy(AddOns* &, AddOns*);					  // copy all table, list recursion
+	void destroy(AddOns* & ptr);							  // destroy everything, list recursion
 	int insert(Attacks *&, Attacks *);					  // insert item, list recursion
 	bool insert(Attacks **, Attacks *);					  // insert item, array recursion
 	void display(Attacks *);							  // display all, list recursion

--- a/addonsdb.h
+++ b/addonsdb.h
@@ -31,12 +31,10 @@ private:
 
 	void copy(AddOns* &, AddOns*);					  // copy all table, list recursion
 	void destroy(AddOns* & ptr);							  // destroy everything, list recursion
-	int insert(Attacks *&, Attacks *);					  // insert item, list recursion
-	bool insert(Attacks **, Attacks *);					  // insert item, array recursion
-	void display(Attacks *);							  // display all, list recursion
-	void display(Attacks **, int = 1);					  // display all, array recursion
-	Attacks *retrieve(Attacks *, int &, bool &, int = 0); // retrieve an attack, list recursion
-	Attacks *retrieve(Attacks **, const string &);		  // retrieve an attack, array recursion
+	bool insert(AddOns* addon);
+	int insert(AddOns* &, AddOns* addon);					  // insert item, list recursion
+	void display(AddOns* );							  // display all, list recursion
+	AddOns* retrieve(AddOns* , int &, bool &, int = 0); // retrieve an attack, list recursion
 	int incrSize();										  // increase size of table array
 
 public:
@@ -44,17 +42,12 @@ public:
 	AddOnsDb(const AddOnsDb &); // copy constructor
 	~AddOnsDb();				// destructor
 
-	bool insert(const Attacks &);								// insert attack, helper function
-	bool insert(const Items &);									// insert item, helper function
 	void display();												// display all, helper function
-	Attacks *retrieve(const string &, const string = "normal"); // retrieve an attack by type
-	Attacks *retrieve();										// retrieve an item
+	AddOns* retrieve(const string &, const string = "normal"); // retrieve an attack by type
+	AddOns* retrieve();										// retrieve an item
 
 	bool addAttacks(const char *); // populate database with file of attacks
 	bool addItems(const char *);   // popluate database with file of items
-
-	AddOnsDb &operator+=(const Attacks &); //+= operator overload to add an attack
-	AddOnsDb &operator+=(const Items &);   //+= operator overload to add an item
 };
 
 #endif

--- a/attacks.cpp
+++ b/attacks.cpp
@@ -12,26 +12,39 @@ was not used in main program.  Information below for functions.
 
 #include "attacks.h"
 
-// default constructor
-Attacks::Attacks() : move(""), type(""), power(0), accuracy(0), pp(0), maxPP(0), next(0), prev(0) {}
+AddOns::AddOns() : next(0), prev(0) {}
 
-// arg constructor using const char* inputs
-Attacks::Attacks(const char *aMove, const char *aType, int pow, int acc, int pp) : move(aMove), type(aType), power(pow), accuracy(acc), pp(pp), maxPP(pp), next(0), prev(0) {}
 
-// arg constructor using string inputs
-Attacks::Attacks(string aMove, string aType, int pow, int acc, int pp) : move(aMove), type(aType), power(pow), accuracy(acc), pp(pp), maxPP(pp), next(0), prev(0) {}
+// connection to next addon
+AddOns* & AddOns::nextLink()
+{
+	return next;
+}
 
-// destructor
-Attacks::~Attacks() {}
+// connection to previous addon
+AddOns* & AddOns::prevLink()
+{
+	return prev;
+}
 
 // display function to output the attack info
-void Attacks::display(ostream &os) const
+void Attacks::display(ostream & os) const
 {
 	os << move << ": " << type << ", " << power << " power, " << accuracy << " accuracy, " << pp << " pp";
 }
 
+// decrease pp, return pp used
+int Attacks::use()
+{
+	if (pp == 0)
+		return 0;
+
+	--pp;
+	return 1;
+}
+
 // compare type of two attacks, return bool
-bool Attacks::compareType(const Attacks &that) const
+bool Attacks::compareType(const Attacks & that) const
 {
 	return type == that.type;
 }
@@ -83,17 +96,6 @@ int Attacks::acc() const
 	return accuracy;
 }
 
-// decrease pp or return false if pp is 0
-bool Attacks::useAttack()
-{
-	bool used = false;
-	if (pp > 0)
-	{
-		--pp;
-		used = true;
-	}
-	return used;
-}
 
 // restore pp to max pp
 bool Attacks::restore()
@@ -101,54 +103,22 @@ bool Attacks::restore()
 	return pp = maxPP;
 }
 
-// required for the hierarchy, no actual body needed for this class
-int Attacks::useItem() const
-{
-	return 0;
-}
-
 //<< operator overloading
-ostream &operator<<(ostream &os, const Attacks &attack)
+ostream &operator<<(ostream & os, const Attacks & attack)
 {
 	attack.display(os);
 	return os;
 }
 
-// connection to next attack
-Attacks *&Attacks::nextLink()
-{
-	return next;
-}
-
-// connection to previous attack
-Attacks *&Attacks::prevLink()
-{
-	return prev;
-}
-
-// default constructor
-Items::Items() : hp(0) {}
-
-// arg constructor using const char* for input
-Items::Items(const char *aName, int hp) : name(aName), hp(hp) {}
-
-// arg constructor using string for input
-Items::Items(string aName, int hp) : name(aName), hp(hp) {}
-
-// copy constructor
-Items::Items(const Items &source) : Attacks(source), name(source.name), hp(source.hp) {}
-
-// destructor
-Items::~Items() {}
 
 // display function to output the item info
-void Items::display(ostream &os) const
+void Items::display(ostream & os) const
 {
 	os << name << ": +" << hp << "hp";
 }
 
 // return hp for calculation
-int Items::useItem() const
+int Items::use()
 {
 	return hp;
 }

--- a/attacks.cpp
+++ b/attacks.cpp
@@ -27,6 +27,28 @@ AddOns* & AddOns::prevLink()
 	return prev;
 }
 
+//<< operator overloading
+ostream &operator<<(ostream & os, const AddOns & addon)
+{
+	addon.display(os);
+	return os;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 // display function to output the attack info
 void Attacks::display(ostream & os) const
 {
@@ -41,6 +63,10 @@ int Attacks::use()
 
 	--pp;
 	return 1;
+}
+
+string Attacks::idType() {
+	return type;
 }
 
 // compare type of two attacks, return bool
@@ -103,12 +129,28 @@ bool Attacks::restore()
 	return pp = maxPP;
 }
 
-//<< operator overloading
-ostream &operator<<(ostream & os, const Attacks & attack)
-{
-	attack.display(os);
-	return os;
+void Attacks::setData(string amove, string atype, int apower, int acc, int amaxPP) {
+	move = amove;
+	type = atype;
+	power = apower;
+	accuracy = acc;
+	pp = amaxPP;
+	maxPP = amaxPP;
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 // display function to output the item info
@@ -121,4 +163,13 @@ void Items::display(ostream & os) const
 int Items::use()
 {
 	return hp;
+}
+
+string Items::idType() {
+	return "item";
+}
+
+void Items::setData(string a_name, int an_hp) {
+	name = a_name;
+	hp = an_hp;
 }

--- a/attacks.h
+++ b/attacks.h
@@ -22,7 +22,20 @@ Items class is derived from Attacks class simply for dynamic binding in AddOnsDb
 
 using namespace std;
 
-class Attacks
+class AddOns {
+	protected:
+		AddOns* next;
+		AddOns* prev;
+
+	public:
+		AddOns();
+		virtual void display(ostream &) const = 0;
+		virtual int use() = 0;
+		AddOns* & nextLink();	// get next pointer
+		AddOns* & prevLink();	// get prev pointer
+};
+
+class Attacks : public AddOns
 {
 private:
 	string move;
@@ -32,17 +45,9 @@ private:
 	int pp;
 	int maxPP;
 
-protected:
-	Attacks *next;
-	Attacks *prev;
-
 public:
-	Attacks();												// default constructor
-	Attacks(const char *, const char *, int, int, int = 5); // arg constructor
-	Attacks(string, string, int, int, int);					// arg constructor
-	virtual ~Attacks();										// destructor
-
-	virtual void display(ostream &) const;					// display data members
+	void display(ostream &) const;					// display data members
+	int use();										// decrement pp by one to use, return false if pp is 0 for attack
 	bool compareType(const Attacks &) const;				// compare the type with another object's type
 	bool compareType(string) const;							// compare the type with input
 	int calcDamage(const float *, const int) const;			// calculate damage
@@ -50,30 +55,19 @@ public:
 	string typ() const;										// return type for damage calculation
 	int pow() const;										// return power for damage calculation
 	int acc() const;										// return accuracy for damage calculation
-	bool useAttack();										// decrement pp by one to use, return false if pp is 0 for attack
 	bool restore();											// restore pp to maxPP
-	virtual int useItem() const;							// only for using dynamic binding for function in Items
 	friend ostream &operator<<(ostream &, const Attacks &); // overload << operator
-
-	Attacks *&nextLink(); // get next pointer
-	Attacks *&prevLink(); // get prev pointer
 };
 
-class Items : public Attacks
+class Items : public AddOns
 {
 private:
 	string name;
 	int hp;
 
 public:
-	Items();				  // default constructor
-	Items(const char *, int); // arg constructor
-	Items(string, int);		  // arg constructor
-	Items(const Items &);	  // copy constructor
-	~Items();				  // destructor
-
 	void display(ostream &) const; // display data members
-	int useItem() const;		   // return hp of item for usage
+	int use();		   // return hp of item for usage
 };
 
 #endif

--- a/attacks.h
+++ b/attacks.h
@@ -31,8 +31,10 @@ class AddOns {
 		AddOns();
 		virtual void display(ostream &) const = 0;
 		virtual int use() = 0;
+		virtual string idType() = 0;
 		AddOns* & nextLink();	// get next pointer
 		AddOns* & prevLink();	// get prev pointer
+		friend ostream &operator<<(ostream &, const AddOns &); // overload << operator
 };
 
 class Attacks : public AddOns
@@ -48,6 +50,9 @@ private:
 public:
 	void display(ostream &) const;					// display data members
 	int use();										// decrement pp by one to use, return false if pp is 0 for attack
+	string idType();
+	void setData(string move, string type, int pow, int acc, int maxPP);
+
 	bool compareType(const Attacks &) const;				// compare the type with another object's type
 	bool compareType(string) const;							// compare the type with input
 	int calcDamage(const float *, const int) const;			// calculate damage
@@ -56,7 +61,6 @@ public:
 	int pow() const;										// return power for damage calculation
 	int acc() const;										// return accuracy for damage calculation
 	bool restore();											// restore pp to maxPP
-	friend ostream &operator<<(ostream &, const Attacks &); // overload << operator
 };
 
 class Items : public AddOns
@@ -68,6 +72,8 @@ private:
 public:
 	void display(ostream &) const; // display data members
 	int use();		   // return hp of item for usage
+	string idType();
+	void setData(string name, int hp);
 };
 
 #endif

--- a/pokemon.cpp
+++ b/pokemon.cpp
@@ -15,103 +15,68 @@ Function information below.
 // default constructor
 Pokemon::Pokemon() : type(normal), status(alive), grown(0), level(0), exp(0), hp(0), maxHP(0), database(0), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)
 {
-	moves = new Attacks *[MAX_MOVES];
-	init(moves);
+	moves = new AddOns* [MAX_MOVES];
+	for (int i {0}; i < MAX_MOVES; ++i)
+		moves[i] = nullptr;
 }
 
 // arg constructor takes a name and database pointer
 Pokemon::Pokemon(AddOnsDb *db, string aName) : type(normal), status(alive), grown(0), level(0), exp(0), hp(0), maxHP(0), name(aName), database(db), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)
 {
-	moves = new Attacks *[MAX_MOVES];
-	init(moves);
+	moves = new AddOns* [MAX_MOVES];
+	for (int i {0}; i < MAX_MOVES; ++i)
+		moves[i] = nullptr;
 }
 
 // copy constructor
 Pokemon::Pokemon(const Pokemon &source) : type(source.type), status(source.status), grown(source.grown), level(source.level), exp(source.exp), hp(source.hp), maxHP(source.maxHP), name(source.name), database(0), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)
 {
 	database = source.database;
-	moves = new Attacks *[source.MAX_MOVES];
-	copy(moves, source.moves);
+	moves = new AddOns* [MAX_MOVES];
+	for (int i {0}; i < MAX_MOVES; ++i)
+		moves[i] = nullptr;
+	copy(source.moves);
 }
 
 // destructor only sets database pointer to null and not delete
 Pokemon::~Pokemon()
 {
 	database = NULL;
-	destroy(moves);
+	destroy();
 	delete[] moves;
 	moves = NULL;
 }
 
-// recursively initialize each array index to 0
-void Pokemon::init(Attacks **arr)
+// copy all from source table
+void Pokemon::copy(AddOns** source)
 {
-	if (arr != moves + MAX_MOVES)
-	{
-		*arr = NULL;
-		init(++arr);
+	if (source[ITEM])
+		moves[ITEM] = new Items(*(dynamic_cast<Items*>(source[ITEM])));
+
+	for (int i {1}; i < MAX_MOVES; ++i) {
+		if (source[i]) {
+			moves[i] = new Attacks(*(dynamic_cast<Attacks*>(source[i])));
+		}
 	}
 }
 
-// recursively copy all from source table
-void Pokemon::copy(Attacks **arr, Attacks **srcTbl)
+// destroy table
+void Pokemon::destroy()
 {
-	*arr = NULL;
-	if (arr != moves + MAX_MOVES)
-	{
-		if (*srcTbl)
-		{
-			if (typeid(*(*srcTbl)) == typeid(Items))
-			{
-				Items *item = dynamic_cast<Items *>(*srcTbl);
-				*arr = new Items(*item);
-			}
-			else
-			{
-				*arr = new Attacks(*(*srcTbl));
-			}
-		}
-		copy(++arr, ++srcTbl);
-	}
-}
-
-// recursively destroy table
-void Pokemon::destroy(Attacks **arr)
-{
-	if (arr != moves + MAX_MOVES)
-	{
-		if (*arr)
-		{
-			delete *arr;
-			*arr = NULL;
-		}
-		destroy(++arr);
-	}
-}
-
-// recursively display moves set with number count in front
-int Pokemon::displayMoves(Attacks **arr, int count) const
-{
-	int has = 0;
-	if (arr != moves + MAX_MOVES)
-	{
-		if (*arr)
-		{
-			cout << count << ". " << *(*arr) << endl;
-			has = displayMoves(++arr, ++count) + 1;
-		}
-		else
-		{
-			has = displayMoves(++arr, ++count);
-		}
-	}
-	return has;
+	for (int i {0}; i < MAX_MOVES; ++i)
+		delete moves[i];
 }
 
 // display moves set helper function
 int Pokemon::displayMoves() const
 {
-	return displayMoves(moves + 1);
+	int has {0};
+	for (int i {1}; i < MAX_MOVES; ++i)
+		if (moves[i]) {
+			++has;
+			cout << has << ". " << *moves[i] << endl;
+		}
+	return has;
 }
 
 // display pokemon full information
@@ -132,7 +97,7 @@ void Pokemon::fullInfo() const
 		cout << name << " is not holding any item\n";
 	}
 	cout << name << "'s moves set\n";
-	displayMoves(moves + 1);
+	displayMoves();
 }
 
 // display only pokemon battle stats
@@ -140,11 +105,6 @@ void Pokemon::battleStats() const
 {
 	char state[][10] = {"alive", "knock-out"};
 	cout << name << "'s current stats-->level: " << level << ", status: " << state[status] << ", hp: " << hp;
-	/*
-		if (holding()) {
-			cout << ", holding a " << *moves[ITEM];
-		}
-	*/
 	cout << endl;
 }
 
@@ -152,72 +112,48 @@ void Pokemon::battleStats() const
 bool Pokemon::learn()
 {
 	char translate[][10] = {"electric", "fire", "water", "grass", "normal"};
-	return learn(translate[type]);
-}
+	string mtype = translate[type];
 
-// learn a new attack by type of pokemon
-// if moves set is full, will prompt for replacement selection
-bool Pokemon::learn(const string &mtype)
-{
-	bool added = false;
-	if (database)
+	if (!database) {
+		cout << "Must add address of AddOnsDb database to initialize pokemon.\n";
+		return false;
+	}
+
+	AddOns* temp = new Attacks(*(dynamic_cast<Attacks*>(database->retrieve(mtype))));
+	cout << name << " wants to learn a new attack! --> " << *temp << endl;
+	char answer = minalib::getYesNo("Do you want to teach your pokemon the above attack (y/n)? ");
+	if (toupper(answer) == 'N')
 	{
-		Attacks *temp = new Attacks(*(database->retrieve(mtype)));
-		cout << name << " wants to learn a new attack! --> " << *temp << endl;
-		char answer = minalib::getYesNo("Do you want to teach your pokemon the above attack (y/n)? ");
-		if (toupper(answer) == 'Y')
-		{
-			added = learn(moves + 1, temp);
-			if (!added)
-			{
-				cout << name << " is full of moves\n";
-				added = switchAttacks(moves + 1, temp);
-				if (!added)
-				{
-					cout << name << " did not learn " << *temp << endl;
-					delete temp;
-				}
-			}
+		cout << name << " did not learn " << *temp << endl;
+		delete temp;
+		return false;
+	}
+
+	bool added {false};
+	for (int i {1}; i < MAX_MOVES; ++i) {
+		if (!moves[i]) {
+			moves[i] = temp;
+			added = true;
 		}
-		else
+	}
+	if (!added)
+	{
+		cout << name << " is full of moves\n";
+		added = switchAttacks(temp);
+		if (!added)
 		{
 			cout << name << " did not learn " << *temp << endl;
 			delete temp;
 		}
 	}
-	else
-	{
-		cout << "Must add address of AddOnsDb database to initialize pokemon.\n";
-	}
 	if (added)
-	{
 		grown = false;
-	}
 	return added;
-}
-
-// add a new attack into move set and return false is moves set is full
-bool Pokemon::learn(Attacks **arr, Attacks *attack)
-{
-	bool done = false;
-	if (arr != moves + MAX_MOVES)
-	{
-		if (*arr)
-		{
-			done = learn(++arr, attack);
-		}
-		else
-		{
-			*arr = attack;
-			done = true;
-		}
-	}
-	return done;
 }
 
 // prompt user to select a move from moves set to switch out for new move
 // return false if user decides not to switch
-bool Pokemon::switchAttacks(Attacks **arr, Attacks *attack)
+bool Pokemon::switchAttacks(AddOns* attack)
 {
 	bool done = false;
 	cout << "0) go back\n";
@@ -239,7 +175,7 @@ bool Pokemon::initialize()
 	bool done = false;
 	if (database)
 	{
-		moves[1] = new Attacks(*(database->retrieve("normal")));
+		moves[1] = new Attacks(*(dynamic_cast<Attacks*>(database->retrieve("normal"))));
 		++level;
 		hp += 500;
 		maxHP += 500;
@@ -253,7 +189,6 @@ bool Pokemon::initialize()
 }
 
 // add new item to moves set else indicate pokemon is holding an item already
-// bool Pokemon::hold(Attacks & item) {
 bool Pokemon::hold(const Items &item)
 {
 	bool take = false;
@@ -270,7 +205,6 @@ bool Pokemon::hold(const Items &item)
 }
 
 //+= operator overload
-// Pokemon & Pokemon::operator+= (Attacks & item) {
 Pokemon &Pokemon::operator+=(const Items &item)
 {
 	hold(item);
@@ -290,18 +224,18 @@ bool Pokemon::attack(Pokemon &opponent)
 {
 	int count = displayMoves();
 	int select = minalib::getInt("Select a move from above to attack: ", 1, count);
-	bool usable = moves[select]->useAttack();
+	bool usable = moves[select]->use();
 	while (!usable)
 	{
 		select = minalib::getInt("No more PP left. Select another move to attack: ", 1, count);
-		usable = moves[select]->useAttack();
+		usable = moves[select]->use();
 	}
-	cout << "You attack with " << moves[select]->mov() << endl;
+	cout << "You attack with " << *moves[select] << endl;
 	if (levelUp())
 	{
 		cout << name << " gained enough experiece to increase to level " << level << "!\n";
 	}
-	return opponent.hit(*moves[select]);
+	return opponent.hit(*(dynamic_cast<Attacks*>(moves[select])));
 }
 
 // return pokemon state for battle use
@@ -329,14 +263,11 @@ void Pokemon::restore()
 {
 	status = alive;
 	hp = maxHP;
-	if (moves[1])
-		moves[1]->restore();
-	if (moves[2])
-		moves[2]->restore();
-	if (moves[3])
-		moves[3]->restore();
-	if (moves[4])
-		moves[4]->restore();
+	for (int i {1}; i < MAX_MOVES; ++i)
+		if (moves[i]) {
+			Attacks* attack = dynamic_cast<Attacks*>(moves[i]);
+			attack->restore();
+		}
 }
 
 // increase a pokemon's level by increasing its experience
@@ -381,10 +312,10 @@ Pokemon &Pokemon::operator=(Pokemon &source)
 		name = source.name;
 		database = source.database;
 
-		destroy(moves);
+		destroy();
 		delete[] moves;
-		moves = new Attacks *[source.MAX_MOVES];
-		copy(moves, source.moves);
+		moves = new AddOns* [MAX_MOVES];
+		copy(source.moves);
 	}
 	return *this;
 }
@@ -402,58 +333,6 @@ istream &operator>>(istream &is, Pokemon &pokemon)
 	is >> pokemon.name;
 	return is;
 }
-
-// return int for char* op,  didn't end up using
-/*
-int Pokemon::whatOp(const char* op) const {
-	char ops[][3] = {"==", "!=", "<=", ">=", "<", ">"};
-	int i = 0;
-	while (strcmp(op, ops[i]) != 0) {
-		++i;
-	}
-	return i;
-}
-
-//compare pokemons by name, didn't end up using
-bool Pokemon::compare(const Pokemon & pokemon, const char* op) const {
-	bool answer = false;
-	int what = whatOp(op);
-	switch (what) {
-		case 0:
-			if (name == pokemon.name) {
-				answer = true;
-			}
-			break;
-		case 1:
-			if (name != pokemon.name) {
-				answer = true;
-			}
-			break;
-		case 2:
-			if (name <= pokemon.name) {
-				answer = true;
-			}
-			break;
-		case 3:
-			if (name >= pokemon.name) {
-				answer = true;
-			}
-			break;
-		case 4:
-			if (name < pokemon.name) {
-				answer = true;
-			}
-			break;
-		case 5:
-			if (name > pokemon.name) {
-				answer = true;
-			}
-			break;
-		default:;
-	}
-	return answer;
-}
-*/
 
 string operator+(const string & str, const Pokemon & pokemon) {
 	return str + pokemon.name;
@@ -599,6 +478,27 @@ bool &Pokemon::rightColor()
 	return rcolor;
 }
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 // default constructor
 Pikachu::Pikachu() : factor(0)
 {
@@ -661,7 +561,7 @@ bool Pikachu::hit(const Attacks &attack)
 	}
 	if (hp < 100 && hp > 0 && holding())
 	{
-		hp += moves[ITEM]->useItem();
+		hp += moves[ITEM]->use();
 		cout << name << " used " << *moves[ITEM] << " to increase its hp by a little!\n";
 		delete moves[ITEM];
 		moves[ITEM] = NULL;
@@ -752,7 +652,7 @@ bool Charmander::hit(const Attacks &attack)
 	}
 	if (hp < 100 && hp > 0 && holding())
 	{
-		hp += moves[ITEM]->useItem();
+		hp += moves[ITEM]->use();
 		cout << name << " used " << *moves[ITEM] << " to increase its hp by a little!\n";
 		delete moves[ITEM];
 		moves[ITEM] = NULL;
@@ -843,7 +743,7 @@ bool Squirtle::hit(const Attacks &attack)
 	}
 	if (hp < 100 && hp > 0 && holding())
 	{
-		hp += moves[ITEM]->useItem();
+		hp += moves[ITEM]->use();
 		cout << name << " used " << *moves[ITEM] << " to increase its hp by a little!\n";
 		delete moves[ITEM];
 		moves[ITEM] = NULL;
@@ -935,7 +835,7 @@ bool Bulbasaur::hit(const Attacks &attack)
 	}
 	if (hp < 100 && hp > 0 && holding())
 	{
-		hp += moves[ITEM]->useItem();
+		hp += moves[ITEM]->use();
 		cout << name << " used " << *moves[ITEM] << " to increase its hp by a little!\n";
 		delete moves[ITEM];
 		moves[ITEM] = NULL;

--- a/pokemon.cpp
+++ b/pokemon.cpp
@@ -134,6 +134,7 @@ bool Pokemon::learn()
 		if (!moves[i]) {
 			moves[i] = temp;
 			added = true;
+			break;
 		}
 	}
 	if (!added)

--- a/pokemon.h
+++ b/pokemon.h
@@ -5,7 +5,7 @@ File name:  pokemon.h
 Class:      CS202
 Term:	    Fall 2020
 
-this is the header file for abstract base class Pokemon and its derived classes
+This is the header file for abstract base class Pokemon and its derived classes
 Pikachu, Charmander, Squirtle, and Bulbasaur.  Each Pokemon derived classes takes
 a pointer to the attacks/items database to populate their moves set.
 */
@@ -21,12 +21,9 @@ using namespace std;
 class Pokemon
 {
 private:
-	void init(Attacks **);						 // initialize array recursion for moves array
-	void copy(Attacks **, Attacks **);			 // copy array recursion for moves array
-	void destroy(Attacks **);					 // destroy array recursion for moves array
-	int displayMoves(Attacks **, int = 1) const; // display array recursion for moves array
-	bool learn(Attacks **, Attacks *);			 // add attack recursion for moves array
-	bool switchAttacks(Attacks **, Attacks *);	 // switch out a current move for a new move
+	void copy(AddOns** source);			 // copy array recursion for moves array
+	void destroy();					 // destroy array recursion for moves array
+	bool switchAttacks(AddOns* attack);	 // switch out a current move for a new move
 
 protected:
 	enum
@@ -55,8 +52,8 @@ protected:
 	int hp;
 	int maxHP;
 	string name;
-	AddOnsDb *database;
-	Attacks **moves;
+	AddOnsDb* database;
+	AddOns** moves;
 
 	enum
 	{
@@ -77,7 +74,6 @@ public:
 	bool initialize();					   // create the baby pokemon
 	int displayMoves() const;			   // display move set
 	bool learn();						   // helper function because each pokemon knows their type
-	bool learn(const string &);			   // helper function takes a string indicating type
 	bool hold(const Items &);			   // have pokemon hold item
 	bool holding() const;				   // return true if moves[ITEM] contains item
 	bool attack(Pokemon &);				   // attack the pokemon
@@ -102,9 +98,6 @@ public:
 	bool compare(const Pokemon &, const char *) const; // compare member function
 	Pokemon &operator=(Pokemon &);					   //= operator overload
 	Pokemon &operator+=(const Items &);				   //+= operator overload to hold item
-
-	// string & operator+=(const char *);
-	// string & operator+=(const string &);
 
 	friend string operator+(const string &, const Pokemon &);
 	friend string operator+(const Pokemon &, const string &);

--- a/pokemon.h
+++ b/pokemon.h
@@ -94,8 +94,6 @@ public:
 	bool &leftColor();	   // return left color for redblack tree
 	bool &rightColor();	   // return right color for redblack tree
 
-	int whatOp(const char *) const;					   // determine what operator for comparison
-	bool compare(const Pokemon &, const char *) const; // compare member function
 	Pokemon &operator=(Pokemon &);					   //= operator overload
 	Pokemon &operator+=(const Items &);				   //+= operator overload to hold item
 


### PR DESCRIPTION
Created abstract base class for Attacks and Items.  Refactored AddOnsDb and Pokemon classes to work with it.  Removed all array recursions in ARR of DLLs.

Reasons:  Array recursion is complex to read and require an extra helper function.  Attacks and Items are not alike besides the fact that they are stored in the same data structure hence it's better for them to derive from an ABC.