### PR TITLE
Fixed double free error and renamed attacks files to addons

### DIFF
--- a/addons.cpp
+++ b/addons.cpp
@@ -1,7 +1,7 @@
 /*
 Programmer: Mina Vu
 Assignment: Prog3
-File name:  attacks.cpp
+File name:  addons.cpp
 Class:      CS202
 Term:	    Fall 2020
 
@@ -10,7 +10,7 @@ Some functions were created for an idea that never manifested or changed and the
 was not used in main program.  Information below for functions.
 */
 
-#include "attacks.h"
+#include "addons.h"
 
 AddOns::AddOns() : next(0), prev(0) {}
 

--- a/addons.h
+++ b/addons.h
@@ -1,7 +1,7 @@
 /*
 Programmer: Mina Vu
 Assignment: Prog3
-File name:  attacks.h
+File name:  addons.h
 Class:      CS202
 Term:	    Fall 2020
 
@@ -9,8 +9,8 @@ This is the header file for the classes Attacks and Items.
 Items class is derived from Attacks class simply for dynamic binding in AddOnsDb.
 */
 
-#ifndef ATTACKS_H
-#define ATTACKS_H
+#ifndef ADDONS_H
+#define ADDONS_H
 
 #include <iostream>
 #include <fstream>

--- a/addonsdb.h
+++ b/addonsdb.h
@@ -18,7 +18,7 @@ AddOnsDb require two .txt files in the specs folder to load attacks and items.
 #include <ctime>
 #include <typeinfo>
 #include <string>
-#include "attacks.h"
+#include "addons.h"
 #include "minalib.h"
 
 using namespace std;

--- a/kanto.cpp
+++ b/kanto.cpp
@@ -173,11 +173,10 @@ void Kanto::searchItem()
 }
 
 void Kanto::foundItem() {
-	Items *item = dynamic_cast<Items *>(database.retrieve());
+	Items* item = new Items(*(dynamic_cast<Items*>(database.retrieve())));
 	cout << "\nYou found a " << *item << endl;
 
-	char answer = minalib::getYesNo("Do you want to give it to a Pokemon? (y/n) ");
-	cout << endl;
+	char answer = minalib::getYesNo("Do you want to give it to a Pokemon? (y/n) "); cout << endl;
 	if (toupper(answer) == 'N')
 	{
 		cout << "\nYou lost the item!\n\n";

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-a.out: main.o minalib.o attacks.o addonsdb.o pokemon.o redblack.o kanto.o
+a.out: main.o minalib.o addons.o addonsdb.o pokemon.o redblack.o kanto.o
 	g++ -g *.o
 
 main.o: main.cpp
@@ -16,8 +16,8 @@ pokemon.o: pokemon.h pokemon.cpp
 addonsdb.o: addonsdb.h addonsdb.cpp
 	g++ -g -c addonsdb.cpp
 
-attacks.o: attacks.h attacks.cpp
-	g++ -g -c attacks.cpp
+addons.o: addons.h addons.cpp
+	g++ -g -c addons.cpp
 
 minalib.o: minalib.h minalib.cpp
 	g++ -g -c minalib.cpp


### PR DESCRIPTION
Fixed double free error in items search and renamed attacks files to addons to reflect the change in class inheritance with new ABC AddOns.