### PR TITLE
Refactor pokemon

### DIFF
--- a/kanto.cpp
+++ b/kanto.cpp
@@ -137,20 +137,20 @@ Pokemon *Kanto::drawPokemonType()
 	switch (randomDraw)
 	{
 	case 1:
-		newPokemon = new Pikachu(&database);
+		newPokemon = new Pikachu();
 		break;
 	case 2:
-		newPokemon = new Charmander(&database);
+		newPokemon = new Charmander();
 		break;
 	case 3:
-		newPokemon = new Squirtle(&database);
+		newPokemon = new Squirtle();
 		break;
 	case 4:
-		newPokemon = new Bulbasaur(&database);
+		newPokemon = new Bulbasaur();
 		break;
 	default:;
 	}
-	newPokemon->initialize();
+	newPokemon->initialize(&database);
 	return newPokemon;
 }
 

--- a/minalib.cpp
+++ b/minalib.cpp
@@ -19,7 +19,7 @@ int minalib::getValidateInt(const char *prompt, int min, int max)
 	{
 		cout << prompt;
 		cin >> num;
-		while (!cin)
+		while (!cin || num < min || num > max)
 		{
 			cin.clear();
 			cin.ignore(100, '\n');
@@ -39,7 +39,7 @@ char minalib::getYesNo(const char *prompt)
 	{
 		cout << prompt;
 		cin >> ch;
-		while (!cin)
+		while (!cin || (toupper(ch) != 'Y' && toupper(ch) != 'N'))
 		{
 			cin.clear();
 			cin.ignore(100, '\n');

--- a/pokemon.h
+++ b/pokemon.h
@@ -68,7 +68,6 @@ protected:
 
 public:
 	Pokemon();					 // default constructor
-	Pokemon(AddOnsDb *, string); // arg constructor takes pointer to database
 	Pokemon(const Pokemon &);	 // copy constructor
 	virtual ~Pokemon();			 // destructor
 
@@ -130,7 +129,6 @@ class Pikachu : public Pokemon
 public:
 	Pikachu();										  // default constructor
 	Pikachu(const Pikachu &);						  // copy constructor
-	~Pikachu();										  // destructor
 
 	bool hit(const Attacks &);	   // take a hit from the opponent
 	void display(ostream &) const; // display Pikachu
@@ -144,7 +142,6 @@ class Charmander : public Pokemon
 public:
 	Charmander();											// default constructor
 	Charmander(const Charmander &);							// copy constructor
-	~Charmander();											// destructor
 
 	bool hit(const Attacks &);	   // take a hit from the opponent
 	void display(ostream &) const; // display Charmander
@@ -158,7 +155,6 @@ class Squirtle : public Pokemon
 public:
 	Squirtle();											// default constructor
 	Squirtle(const Squirtle &);							// copy constructor
-	~Squirtle();										// destructor
 
 	bool hit(const Attacks &);	   // take a hit from the opponent
 	void display(ostream &) const; // display Squirtle
@@ -172,7 +168,6 @@ class Bulbasaur : public Pokemon
 public:
 	Bulbasaur();										  // default constructor
 	Bulbasaur(const Bulbasaur &);						  // copy constructor
-	~Bulbasaur();										  // destructor
 
 	bool hit(const Attacks &);	   // take a hit from the opponent
 	void display(ostream &) const; // display Bulbasaur

--- a/pokemon.h
+++ b/pokemon.h
@@ -52,6 +52,7 @@ protected:
 	int hp;
 	int maxHP;
 	string name;
+	float *factor;
 	AddOnsDb *database;
 	AddOns **moves;
 
@@ -126,9 +127,6 @@ public:
 
 class Pikachu : public Pokemon
 {
-private:
-	float *factor;
-
 public:
 	Pikachu();										  // default constructor
 	explicit Pikachu(AddOnsDb *, string = "Pikachu"); // arg constructor
@@ -144,9 +142,6 @@ public:
 
 class Charmander : public Pokemon
 {
-private:
-	float *factor;
-
 public:
 	Charmander();											// default constructor
 	explicit Charmander(AddOnsDb *, string = "Charmander"); // arg constructor
@@ -162,9 +157,6 @@ public:
 
 class Squirtle : public Pokemon
 {
-private:
-	float *factor;
-
 public:
 	Squirtle();											// default constructor
 	explicit Squirtle(AddOnsDb *, string = "Squirtle"); // arg constructor
@@ -180,9 +172,6 @@ public:
 
 class Bulbasaur : public Pokemon
 {
-private:
-	float *factor;
-
 public:
 	Bulbasaur();										  // default constructor
 	explicit Bulbasaur(AddOnsDb *, string = "Bulbasaur"); // arg constructor

--- a/pokemon.h
+++ b/pokemon.h
@@ -69,11 +69,10 @@ protected:
 public:
 	Pokemon();					 // default constructor
 	Pokemon(const Pokemon &);	 // copy constructor
-	virtual ~Pokemon();			 // destructor
+	virtual ~Pokemon() = 0;			 // destructor
 
-	virtual bool hit(const Attacks &) = 0;	   // take a hit from the opponent
 	virtual void displayFullInfo() const;	   // display all info
-
+	bool hit(const Attacks &);	   // take a hit from the opponent
 	bool initialize(AddOnsDb* db);				 // create the baby pokemon
 	int displayMoves() const;		 // display move set
 	bool learnNewAttack();			 // helper function because each pokemon knows their type
@@ -128,11 +127,9 @@ class Pikachu : public Pokemon
 public:
 	Pikachu();										  // default constructor
 	Pikachu(const Pikachu &);						  // copy constructor
-
-	bool hit(const Attacks &);	   // take a hit from the opponent
-	void displayFullInfo() const;  // display all info
-
 	Pikachu &operator=(Pikachu &); // overload = operator
+
+	void displayFullInfo() const;  // display all info
 };
 
 class Charmander : public Pokemon
@@ -140,11 +137,9 @@ class Charmander : public Pokemon
 public:
 	Charmander();											// default constructor
 	Charmander(const Charmander &);							// copy constructor
-
-	bool hit(const Attacks &);	   // take a hit from the opponent
-	void displayFullInfo() const;  // display all info
-
 	Charmander &operator=(Charmander &); // overload = operator
+
+	void displayFullInfo() const;  // display all info
 };
 
 class Squirtle : public Pokemon
@@ -152,11 +147,9 @@ class Squirtle : public Pokemon
 public:
 	Squirtle();											// default constructor
 	Squirtle(const Squirtle &);							// copy constructor
-
-	bool hit(const Attacks &);	   // take a hit from the opponent
-	void displayFullInfo() const;  // display all info
-
 	Squirtle &operator=(Squirtle &); // overload = operator
+
+	void displayFullInfo() const;  // display all info
 };
 
 class Bulbasaur : public Pokemon
@@ -164,11 +157,9 @@ class Bulbasaur : public Pokemon
 public:
 	Bulbasaur();										  // default constructor
 	Bulbasaur(const Bulbasaur &);						  // copy constructor
-
-	bool hit(const Attacks &);	   // take a hit from the opponent
-	void displayFullInfo() const;  // display all info
-
 	Bulbasaur &operator=(Bulbasaur &); // overload = operator
+
+	void displayFullInfo() const;  // display all info
 };
 
 #endif

--- a/pokemon.h
+++ b/pokemon.h
@@ -52,8 +52,8 @@ protected:
 	int hp;
 	int maxHP;
 	string name;
-	float *factor;
 	AddOnsDb *database;
+	float *factor;
 	AddOns **moves;
 
 	enum
@@ -76,7 +76,7 @@ public:
 	virtual void display(ostream &) const = 0; // display Pokemon
 	virtual void displayFullInfo() const;	   // display all info
 
-	bool initialize();				 // create the baby pokemon
+	bool initialize(AddOnsDb* db);				 // create the baby pokemon
 	int displayMoves() const;		 // display move set
 	bool learnNewAttack();			 // helper function because each pokemon knows their type
 	bool hold(const Items &);		 // have pokemon hold item
@@ -129,7 +129,6 @@ class Pikachu : public Pokemon
 {
 public:
 	Pikachu();										  // default constructor
-	explicit Pikachu(AddOnsDb *, string = "Pikachu"); // arg constructor
 	Pikachu(const Pikachu &);						  // copy constructor
 	~Pikachu();										  // destructor
 
@@ -144,7 +143,6 @@ class Charmander : public Pokemon
 {
 public:
 	Charmander();											// default constructor
-	explicit Charmander(AddOnsDb *, string = "Charmander"); // arg constructor
 	Charmander(const Charmander &);							// copy constructor
 	~Charmander();											// destructor
 
@@ -159,7 +157,6 @@ class Squirtle : public Pokemon
 {
 public:
 	Squirtle();											// default constructor
-	explicit Squirtle(AddOnsDb *, string = "Squirtle"); // arg constructor
 	Squirtle(const Squirtle &);							// copy constructor
 	~Squirtle();										// destructor
 
@@ -174,7 +171,6 @@ class Bulbasaur : public Pokemon
 {
 public:
 	Bulbasaur();										  // default constructor
-	explicit Bulbasaur(AddOnsDb *, string = "Bulbasaur"); // arg constructor
 	Bulbasaur(const Bulbasaur &);						  // copy constructor
 	~Bulbasaur();										  // destructor
 

--- a/pokemon.h
+++ b/pokemon.h
@@ -72,7 +72,6 @@ public:
 	virtual ~Pokemon();			 // destructor
 
 	virtual bool hit(const Attacks &) = 0;	   // take a hit from the opponent
-	virtual void display(ostream &) const = 0; // display Pokemon
 	virtual void displayFullInfo() const;	   // display all info
 
 	bool initialize(AddOnsDb* db);				 // create the baby pokemon
@@ -131,7 +130,6 @@ public:
 	Pikachu(const Pikachu &);						  // copy constructor
 
 	bool hit(const Attacks &);	   // take a hit from the opponent
-	void display(ostream &) const; // display Pikachu
 	void displayFullInfo() const;  // display all info
 
 	Pikachu &operator=(Pikachu &); // overload = operator
@@ -144,7 +142,6 @@ public:
 	Charmander(const Charmander &);							// copy constructor
 
 	bool hit(const Attacks &);	   // take a hit from the opponent
-	void display(ostream &) const; // display Charmander
 	void displayFullInfo() const;  // display all info
 
 	Charmander &operator=(Charmander &); // overload = operator
@@ -157,7 +154,6 @@ public:
 	Squirtle(const Squirtle &);							// copy constructor
 
 	bool hit(const Attacks &);	   // take a hit from the opponent
-	void display(ostream &) const; // display Squirtle
 	void displayFullInfo() const;  // display all info
 
 	Squirtle &operator=(Squirtle &); // overload = operator
@@ -170,7 +166,6 @@ public:
 	Bulbasaur(const Bulbasaur &);						  // copy constructor
 
 	bool hit(const Attacks &);	   // take a hit from the opponent
-	void display(ostream &) const; // display Bulbasaur
 	void displayFullInfo() const;  // display all info
 
 	Bulbasaur &operator=(Bulbasaur &); // overload = operator

--- a/pokemonabc.cpp
+++ b/pokemonabc.cpp
@@ -11,7 +11,7 @@ This file contains the implementations for class Pokemon.  Pokemon is an ABC.
 #include "pokemon.h"
 
 // default constructor
-Pokemon::Pokemon() : type(normal), status(alive), grown(0), level(0), exp(0), hp(0), maxHP(0), database(0), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)
+Pokemon::Pokemon() : type(normal), status(alive), grown(0), level(0), exp(0), hp(0), maxHP(0), factor(0), database(0), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)
 {
 	moves = new AddOns *[MAX_MOVES];
 	for (int i{0}; i < MAX_MOVES; ++i)
@@ -19,7 +19,7 @@ Pokemon::Pokemon() : type(normal), status(alive), grown(0), level(0), exp(0), hp
 }
 
 // arg constructor takes a name and database pointer
-Pokemon::Pokemon(AddOnsDb *db, string aName) : type(normal), status(alive), grown(0), level(0), exp(0), hp(0), maxHP(0), name(aName), database(db), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)
+Pokemon::Pokemon(AddOnsDb *db, string aName) : type(normal), status(alive), grown(0), level(0), exp(0), hp(0), maxHP(0), factor(0), name(aName), database(db), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)
 {
 	moves = new AddOns *[MAX_MOVES];
 	for (int i{0}; i < MAX_MOVES; ++i)
@@ -27,7 +27,7 @@ Pokemon::Pokemon(AddOnsDb *db, string aName) : type(normal), status(alive), grow
 }
 
 // copy constructor
-Pokemon::Pokemon(const Pokemon &source) : type(source.type), status(source.status), grown(source.grown), level(source.level), exp(source.exp), hp(source.hp), maxHP(source.maxHP), name(source.name), database(source.database), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)
+Pokemon::Pokemon(const Pokemon &source) : type(source.type), status(source.status), grown(source.grown), level(source.level), exp(source.exp), hp(source.hp), maxHP(source.maxHP), factor(0), name(source.name), database(source.database), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)
 {
 	moves = new AddOns *[MAX_MOVES];
 	for (int i{0}; i < MAX_MOVES; ++i)

--- a/pokemonabc.cpp
+++ b/pokemonabc.cpp
@@ -290,6 +290,11 @@ Pokemon &Pokemon::operator=(Pokemon &source)
 	name = source.name;
 	database = source.database;
 
+	delete[] factor;
+	factor = new float[TYPES];
+	for (int i = 0; i < TYPES; ++i)
+		factor[i] = source.factor[i];
+
 	destroyMovesList();
 	delete[] moves;
 	moves = new AddOns *[MAX_MOVES];

--- a/pokemonabc.cpp
+++ b/pokemonabc.cpp
@@ -18,14 +18,6 @@ Pokemon::Pokemon() : type(normal), status(alive), grown(0), level(0), exp(0), hp
 		moves[i] = nullptr;
 }
 
-// arg constructor takes a name and database pointer
-Pokemon::Pokemon(AddOnsDb *db, string aName) : type(normal), status(alive), grown(0), level(0), exp(0), hp(0), maxHP(0), factor(0), name(aName), database(db), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)
-{
-	moves = new AddOns *[MAX_MOVES];
-	for (int i{0}; i < MAX_MOVES; ++i)
-		moves[i] = nullptr;
-}
-
 // copy constructor
 Pokemon::Pokemon(const Pokemon &source) : type(source.type), status(source.status), grown(source.grown), level(source.level), exp(source.exp), hp(source.hp), maxHP(source.maxHP), factor(0), name(source.name), database(source.database), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)
 {
@@ -43,6 +35,8 @@ Pokemon::Pokemon(const Pokemon &source) : type(source.type), status(source.statu
 Pokemon::~Pokemon()
 {
 	database = NULL;
+	delete[] factor;
+	factor = nullptr;
 	destroyMovesList();
 	delete[] moves;
 	moves = NULL;

--- a/pokemonabc.cpp
+++ b/pokemonabc.cpp
@@ -306,7 +306,7 @@ Pokemon &Pokemon::operator=(Pokemon &source)
 //<< operator overloading
 ostream &operator<<(ostream &os, const Pokemon &pokemon)
 {
-	pokemon.display(os);
+	os << pokemon.name;
 	return os;
 }
 

--- a/pokemonabc.cpp
+++ b/pokemonabc.cpp
@@ -228,6 +228,35 @@ bool Pokemon::attack(Pokemon &opponent)
 	return opponent.hit(*(dynamic_cast<Attacks *>(moves[select])));
 }
 
+// takes damage an attack, use item if holding item, and change status if hp reaches 0
+bool Pokemon::hit(const Attacks &attack)
+{
+	bool hurt = false;
+	int damage = attack.calcDamage(factor, type);
+	if (damage)
+	{
+		hp -= damage;
+		hurt = true;
+	}
+	else
+	{
+		cout << "Hooray! " << name << " dodged the attack!\n";
+	}
+	if (hp < 100 && hp > 0 && isHoldingItem())
+	{
+		hp += moves[ITEM]->use();
+		cout << name << " used " << *moves[ITEM] << " to increase its hp by a little!\n";
+		delete moves[ITEM];
+		moves[ITEM] = NULL;
+	}
+	if (hp <= 0)
+	{
+		hp = 0;
+		status = ko;
+	}
+	return hurt;
+}
+
 // return pokemon state for battle use
 bool Pokemon::isAlive()
 {

--- a/pokemonabc.cpp
+++ b/pokemonabc.cpp
@@ -29,6 +29,10 @@ Pokemon::Pokemon(AddOnsDb *db, string aName) : type(normal), status(alive), grow
 // copy constructor
 Pokemon::Pokemon(const Pokemon &source) : type(source.type), status(source.status), grown(source.grown), level(source.level), exp(source.exp), hp(source.hp), maxHP(source.maxHP), factor(0), name(source.name), database(source.database), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)
 {
+	factor = new float[TYPES];
+	for (int i = 0; i < TYPES; ++i)
+		factor[i] = source.factor[i];
+
 	moves = new AddOns *[MAX_MOVES];
 	for (int i{0}; i < MAX_MOVES; ++i)
 		moves[i] = nullptr;
@@ -169,14 +173,9 @@ bool Pokemon::switchAttacks(AddOns *attack)
 }
 
 // initializes pokemon with level, hp, and starting move
-bool Pokemon::initialize()
+bool Pokemon::initialize(AddOnsDb* db)
 {
-	if (!database)
-	{
-		cout << "Must add database\n";
-		return false;
-	}
-
+	database = db;
 	moves[1] = new Attacks(*(dynamic_cast<Attacks *>(database->retrieveAttack("normal"))));
 	++level;
 	hp += 500;

--- a/pokemonsub.cpp
+++ b/pokemonsub.cpp
@@ -22,13 +22,6 @@ Pikachu::Pikachu()
 // copy constructor
 Pikachu::Pikachu(const Pikachu &source) : Pokemon(source) {}
 
-// display pikachu name
-// had more to this before ideas changed
-void Pikachu::display(ostream &os) const
-{
-	os << name;
-}
-
 // display pikachu's full information
 void Pikachu::displayFullInfo() const
 {
@@ -82,12 +75,6 @@ Charmander::Charmander()
 
 // copy constructor
 Charmander::Charmander(const Charmander &source) : Pokemon(source) {}
-
-// display charmander's name
-void Charmander::display(ostream &os) const
-{
-	os << name;
-}
 
 // display charmander's full info
 void Charmander::displayFullInfo() const
@@ -143,12 +130,6 @@ Squirtle::Squirtle()
 // copy constructor
 Squirtle::Squirtle(const Squirtle &source) : Pokemon(source) {}
 
-// display squirtle's name
-void Squirtle::display(ostream &os) const
-{
-	os << name;
-}
-
 // display full info
 void Squirtle::displayFullInfo() const
 {
@@ -202,12 +183,6 @@ Bulbasaur::Bulbasaur()
 
 // copy construcotr
 Bulbasaur::Bulbasaur(const Bulbasaur &source) : Pokemon(source) {}
-
-// display Bulbasaur's name
-void Bulbasaur::display(ostream &os) const
-{
-	os << name;
-}
 
 // display full information
 void Bulbasaur::displayFullInfo() const

--- a/pokemonsub.cpp
+++ b/pokemonsub.cpp
@@ -12,21 +12,21 @@ Squirtle, and Bulbasaur.
 #include "pokemon.h"
 
 // default constructor
-Pikachu::Pikachu() : factor(0)
+Pikachu::Pikachu()
 {
 	factor = new float[TYPES]{1.0, 2.0, 2.0, 1.0, 1.0};
 	type = electric;
 }
 
 // arg constructor
-Pikachu::Pikachu(AddOnsDb *db, string aName) : Pokemon(db, aName), factor(0)
+Pikachu::Pikachu(AddOnsDb *db, string aName) : Pokemon(db, aName)
 {
 	factor = new float[TYPES]{1.0, 2.0, 2.0, 1.0, 1.0};
 	type = electric;
 }
 
 // copy constructor
-Pikachu::Pikachu(const Pikachu &source) : Pokemon(source), factor(0)
+Pikachu::Pikachu(const Pikachu &source) : Pokemon(source)
 {
 	factor = new float[source.TYPES];
 	for (int i = 0; i < source.TYPES; ++i)
@@ -104,21 +104,21 @@ Pikachu &Pikachu::operator=(Pikachu &source)
 }
 
 // default constructor
-Charmander::Charmander() : factor(0)
+Charmander::Charmander()
 {
 	factor = new float[TYPES]{2.0, 1.0, 0.5, 2.5, 1.0};
 	type = fire;
 }
 
 // arg constructor
-Charmander::Charmander(AddOnsDb *db, string aName) : Pokemon(db, aName), factor(0)
+Charmander::Charmander(AddOnsDb *db, string aName) : Pokemon(db, aName)
 {
 	factor = new float[TYPES]{2.0, 1.0, 0.5, 2.5, 1.0};
 	type = fire;
 }
 
 // copy constructor
-Charmander::Charmander(const Charmander &source) : Pokemon(source), factor(0)
+Charmander::Charmander(const Charmander &source) : Pokemon(source)
 {
 	factor = new float[source.TYPES];
 	for (int i = 0; i < source.TYPES; ++i)
@@ -195,21 +195,21 @@ Charmander &Charmander::operator=(Charmander &source)
 }
 
 // default constructor
-Squirtle::Squirtle() : factor(0)
+Squirtle::Squirtle()
 {
 	factor = new float[TYPES]{2.0, 2.5, 1.0, 0.5, 1.0};
 	type = water;
 }
 
 // arg constructor
-Squirtle::Squirtle(AddOnsDb *db, string aName) : Pokemon(db, aName), factor(0)
+Squirtle::Squirtle(AddOnsDb *db, string aName) : Pokemon(db, aName)
 {
 	factor = new float[TYPES]{2.0, 2.5, 1.0, 0.5, 1.0};
 	type = water;
 }
 
 // copy constructor
-Squirtle::Squirtle(const Squirtle &source) : Pokemon(source), factor(0)
+Squirtle::Squirtle(const Squirtle &source) : Pokemon(source)
 {
 	factor = new float[source.TYPES];
 	for (int i = 0; i < source.TYPES; ++i)
@@ -286,21 +286,21 @@ Squirtle &Squirtle::operator=(Squirtle &source)
 }
 
 // default constructor
-Bulbasaur::Bulbasaur() : factor(0)
+Bulbasaur::Bulbasaur()
 {
 	factor = new float[TYPES]{1.0, 0.5, 2.5, 1.0, 1.0};
 	type = grass;
 }
 
 // arg constructor
-Bulbasaur::Bulbasaur(AddOnsDb *db, string aName) : Pokemon(db, aName), factor(0)
+Bulbasaur::Bulbasaur(AddOnsDb *db, string aName) : Pokemon(db, aName)
 {
 	factor = new float[TYPES]{1.0, 0.5, 2.5, 1.0, 1.0};
 	type = grass;
 }
 
 // copy construcotr
-Bulbasaur::Bulbasaur(const Bulbasaur &source) : Pokemon(source), factor(0)
+Bulbasaur::Bulbasaur(const Bulbasaur &source) : Pokemon(source)
 {
 	factor = new float[source.TYPES];
 	for (int i = 0; i < source.TYPES; ++i)

--- a/pokemonsub.cpp
+++ b/pokemonsub.cpp
@@ -16,13 +16,7 @@ Pikachu::Pikachu()
 {
 	factor = new float[TYPES]{1.0, 2.0, 2.0, 1.0, 1.0};
 	type = electric;
-}
-
-// arg constructor
-Pikachu::Pikachu(AddOnsDb *db, string aName) : Pokemon(db, aName)
-{
-	factor = new float[TYPES]{1.0, 2.0, 2.0, 1.0, 1.0};
-	type = electric;
+	name = "Pikachu";
 }
 
 // copy constructor
@@ -108,13 +102,7 @@ Charmander::Charmander()
 {
 	factor = new float[TYPES]{2.0, 1.0, 0.5, 2.5, 1.0};
 	type = fire;
-}
-
-// arg constructor
-Charmander::Charmander(AddOnsDb *db, string aName) : Pokemon(db, aName)
-{
-	factor = new float[TYPES]{2.0, 1.0, 0.5, 2.5, 1.0};
-	type = fire;
+	name = "Charmander";
 }
 
 // copy constructor
@@ -199,13 +187,7 @@ Squirtle::Squirtle()
 {
 	factor = new float[TYPES]{2.0, 2.5, 1.0, 0.5, 1.0};
 	type = water;
-}
-
-// arg constructor
-Squirtle::Squirtle(AddOnsDb *db, string aName) : Pokemon(db, aName)
-{
-	factor = new float[TYPES]{2.0, 2.5, 1.0, 0.5, 1.0};
-	type = water;
+	name = "Squirtle";
 }
 
 // copy constructor
@@ -290,13 +272,7 @@ Bulbasaur::Bulbasaur()
 {
 	factor = new float[TYPES]{1.0, 0.5, 2.5, 1.0, 1.0};
 	type = grass;
-}
-
-// arg constructor
-Bulbasaur::Bulbasaur(AddOnsDb *db, string aName) : Pokemon(db, aName)
-{
-	factor = new float[TYPES]{1.0, 0.5, 2.5, 1.0, 1.0};
-	type = grass;
+	name = "Bulbasaur";
 }
 
 // copy construcotr

--- a/pokemonsub.cpp
+++ b/pokemonsub.cpp
@@ -22,47 +22,18 @@ Pikachu::Pikachu()
 // copy constructor
 Pikachu::Pikachu(const Pikachu &source) : Pokemon(source) {}
 
+// = operator overload
+Pikachu &Pikachu::operator=(Pikachu &source)
+{
+	Pokemon::operator=(source);
+	return *this;
+}
+
 // display pikachu's full information
 void Pikachu::displayFullInfo() const
 {
 	cout << "Your Pikachu's name is: " << name << endl;
 	Pokemon::displayFullInfo();
-}
-
-// takes damage an attack, use item if holding item, and change status if hp reaches 0
-bool Pikachu::hit(const Attacks &attack)
-{
-	bool hurt = false;
-	int damage = attack.calcDamage(factor, type);
-	if (damage)
-	{
-		hp -= damage;
-		hurt = true;
-	}
-	else
-	{
-		cout << "Hooray! " << name << " dodged the attack!\n";
-	}
-	if (hp < 100 && hp > 0 && isHoldingItem())
-	{
-		hp += moves[ITEM]->use();
-		cout << name << " used " << *moves[ITEM] << " to increase its hp by a little!\n";
-		delete moves[ITEM];
-		moves[ITEM] = NULL;
-	}
-	if (hp <= 0)
-	{
-		hp = 0;
-		status = ko;
-	}
-	return hurt;
-}
-
-//= operator overload
-Pikachu &Pikachu::operator=(Pikachu &source)
-{
-	Pokemon::operator=(source);
-	return *this;
 }
 
 // default constructor
@@ -76,47 +47,18 @@ Charmander::Charmander()
 // copy constructor
 Charmander::Charmander(const Charmander &source) : Pokemon(source) {}
 
+// = operator overload
+Charmander &Charmander::operator=(Charmander &source)
+{
+	Pokemon::operator=(source);
+	return *this;
+}
+
 // display charmander's full info
 void Charmander::displayFullInfo() const
 {
 	cout << "Your Charmander's name is: " << name << endl;
 	Pokemon::displayFullInfo();
-}
-
-// take damage from an attack, use item if holding, change status if knocked out
-bool Charmander::hit(const Attacks &attack)
-{
-	bool hurt = false;
-	int damage = attack.calcDamage(factor, type);
-	if (damage)
-	{
-		hp -= damage;
-		hurt = true;
-	}
-	else
-	{
-		cout << "Hooray! " << name << " dodged the attack!\n";
-	}
-	if (hp < 100 && hp > 0 && isHoldingItem())
-	{
-		hp += moves[ITEM]->use();
-		cout << name << " used " << *moves[ITEM] << " to increase its hp by a little!\n";
-		delete moves[ITEM];
-		moves[ITEM] = NULL;
-	}
-	if (hp <= 0)
-	{
-		hp = 0;
-		status = ko;
-	}
-	return hurt;
-}
-
-//= operator overload
-Charmander &Charmander::operator=(Charmander &source)
-{
-	Pokemon::operator=(source);
-	return *this;
 }
 
 // default constructor
@@ -130,47 +72,18 @@ Squirtle::Squirtle()
 // copy constructor
 Squirtle::Squirtle(const Squirtle &source) : Pokemon(source) {}
 
-// display full info
-void Squirtle::displayFullInfo() const
-{
-	cout << "Your Squirtle's name is: " << name << endl;
-	Pokemon::displayFullInfo();
-}
-
-// take damage from an attack
-bool Squirtle::hit(const Attacks &attack)
-{
-	bool hurt = false;
-	int damage = attack.calcDamage(factor, type);
-	if (damage)
-	{
-		hp -= damage;
-		hurt = true;
-	}
-	else
-	{
-		cout << "Hooray! " << name << " dodged the attack!\n";
-	}
-	if (hp < 100 && hp > 0 && isHoldingItem())
-	{
-		hp += moves[ITEM]->use();
-		cout << name << " used " << *moves[ITEM] << " to increase its hp by a little!\n";
-		delete moves[ITEM];
-		moves[ITEM] = NULL;
-	}
-	if (hp <= 0)
-	{
-		hp = 0;
-		status = ko;
-	}
-	return hurt;
-}
-
-//= operator overload
+// = operator overload
 Squirtle &Squirtle::operator=(Squirtle &source)
 {
 	Pokemon::operator=(source);
 	return *this;
+}
+
+// display squirtle's full info
+void Squirtle::displayFullInfo() const
+{
+	cout << "Your Squirtle's name is: " << name << endl;
+	Pokemon::displayFullInfo();
 }
 
 // default constructor
@@ -184,46 +97,16 @@ Bulbasaur::Bulbasaur()
 // copy construcotr
 Bulbasaur::Bulbasaur(const Bulbasaur &source) : Pokemon(source) {}
 
-// display full information
-void Bulbasaur::displayFullInfo() const
-{
-	cout << "Your Bulbasaur's name is: " << name << endl;
-	Pokemon::displayFullInfo();
-}
-
-// take damage from an attack
-// these were placed in the derived class because of an early idea that didn't pan out
-bool Bulbasaur::hit(const Attacks &attack)
-{
-	bool hurt = false;
-	int damage = attack.calcDamage(factor, type);
-	if (damage)
-	{
-		hp -= damage;
-		hurt = true;
-	}
-	else
-	{
-		cout << "Hooray! " << name << " dodged the attack!\n";
-	}
-	if (hp < 100 && hp > 0 && isHoldingItem())
-	{
-		hp += moves[ITEM]->use();
-		cout << name << " used " << *moves[ITEM] << " to increase its hp by a little!\n";
-		delete moves[ITEM];
-		moves[ITEM] = NULL;
-	}
-	if (hp <= 0)
-	{
-		hp = 0;
-		status = ko;
-	}
-	return hurt;
-}
-
-//= operator overload
+// = operator overload
 Bulbasaur &Bulbasaur::operator=(Bulbasaur &source)
 {
 	Pokemon::operator=(source);
 	return *this;
+}
+
+// display bulbasaur's full info
+void Bulbasaur::displayFullInfo() const
+{
+	cout << "Your Bulbasaur's name is: " << name << endl;
+	Pokemon::displayFullInfo();
 }

--- a/pokemonsub.cpp
+++ b/pokemonsub.cpp
@@ -20,15 +20,7 @@ Pikachu::Pikachu()
 }
 
 // copy constructor
-Pikachu::Pikachu(const Pikachu &source) : Pokemon(source)
-{
-	factor = new float[source.TYPES];
-	for (int i = 0; i < source.TYPES; ++i)
-	{
-		factor[i] = source.factor[i];
-	}
-	type = source.type;
-}
+Pikachu::Pikachu(const Pikachu &source) : Pokemon(source) {}
 
 // display pikachu name
 // had more to this before ideas changed
@@ -76,17 +68,7 @@ bool Pikachu::hit(const Attacks &attack)
 //= operator overload
 Pikachu &Pikachu::operator=(Pikachu &source)
 {
-	if (&source != this)
-	{
-		Pokemon::operator=(source);
-		delete[] factor;
-		factor = new float[source.TYPES];
-		for (int i = 0; i < source.TYPES; ++i)
-		{
-			factor[i] = source.factor[i];
-		}
-		type = source.type;
-	}
+	Pokemon::operator=(source);
 	return *this;
 }
 
@@ -99,15 +81,7 @@ Charmander::Charmander()
 }
 
 // copy constructor
-Charmander::Charmander(const Charmander &source) : Pokemon(source)
-{
-	factor = new float[source.TYPES];
-	for (int i = 0; i < source.TYPES; ++i)
-	{
-		factor[i] = source.factor[i];
-	}
-	type = source.type;
-}
+Charmander::Charmander(const Charmander &source) : Pokemon(source) {}
 
 // display charmander's name
 void Charmander::display(ostream &os) const
@@ -154,17 +128,7 @@ bool Charmander::hit(const Attacks &attack)
 //= operator overload
 Charmander &Charmander::operator=(Charmander &source)
 {
-	if (&source != this)
-	{
-		Pokemon::operator=(source);
-		delete[] factor;
-		factor = new float[source.TYPES];
-		for (int i = 0; i < source.TYPES; ++i)
-		{
-			factor[i] = source.factor[i];
-		}
-		type = source.type;
-	}
+	Pokemon::operator=(source);
 	return *this;
 }
 
@@ -177,15 +141,7 @@ Squirtle::Squirtle()
 }
 
 // copy constructor
-Squirtle::Squirtle(const Squirtle &source) : Pokemon(source)
-{
-	factor = new float[source.TYPES];
-	for (int i = 0; i < source.TYPES; ++i)
-	{
-		factor[i] = source.factor[i];
-	}
-	type = source.type;
-}
+Squirtle::Squirtle(const Squirtle &source) : Pokemon(source) {}
 
 // display squirtle's name
 void Squirtle::display(ostream &os) const
@@ -232,17 +188,7 @@ bool Squirtle::hit(const Attacks &attack)
 //= operator overload
 Squirtle &Squirtle::operator=(Squirtle &source)
 {
-	if (&source != this)
-	{
-		Pokemon::operator=(source);
-		delete[] factor;
-		factor = new float[source.TYPES];
-		for (int i = 0; i < source.TYPES; ++i)
-		{
-			factor[i] = source.factor[i];
-		}
-		type = source.type;
-	}
+	Pokemon::operator=(source);
 	return *this;
 }
 
@@ -255,15 +201,7 @@ Bulbasaur::Bulbasaur()
 }
 
 // copy construcotr
-Bulbasaur::Bulbasaur(const Bulbasaur &source) : Pokemon(source)
-{
-	factor = new float[source.TYPES];
-	for (int i = 0; i < source.TYPES; ++i)
-	{
-		factor[i] = source.factor[i];
-	}
-	type = source.type;
-}
+Bulbasaur::Bulbasaur(const Bulbasaur &source) : Pokemon(source) {}
 
 // display Bulbasaur's name
 void Bulbasaur::display(ostream &os) const
@@ -311,16 +249,6 @@ bool Bulbasaur::hit(const Attacks &attack)
 //= operator overload
 Bulbasaur &Bulbasaur::operator=(Bulbasaur &source)
 {
-	if (&source != this)
-	{
-		Pokemon::operator=(source);
-		delete[] factor;
-		factor = new float[source.TYPES];
-		for (int i = 0; i < source.TYPES; ++i)
-		{
-			factor[i] = source.factor[i];
-		}
-		type = source.type;
-	}
+	Pokemon::operator=(source);
 	return *this;
 }

--- a/pokemonsub.cpp
+++ b/pokemonsub.cpp
@@ -30,13 +30,6 @@ Pikachu::Pikachu(const Pikachu &source) : Pokemon(source)
 	type = source.type;
 }
 
-// destructor
-Pikachu::~Pikachu()
-{
-	delete[] factor;
-	factor = NULL;
-}
-
 // display pikachu name
 // had more to this before ideas changed
 void Pikachu::display(ostream &os) const
@@ -114,13 +107,6 @@ Charmander::Charmander(const Charmander &source) : Pokemon(source)
 		factor[i] = source.factor[i];
 	}
 	type = source.type;
-}
-
-// destructor
-Charmander::~Charmander()
-{
-	delete[] factor;
-	factor = NULL;
 }
 
 // display charmander's name
@@ -201,13 +187,6 @@ Squirtle::Squirtle(const Squirtle &source) : Pokemon(source)
 	type = source.type;
 }
 
-// destructor
-Squirtle::~Squirtle()
-{
-	delete[] factor;
-	factor = NULL;
-}
-
 // display squirtle's name
 void Squirtle::display(ostream &os) const
 {
@@ -284,13 +263,6 @@ Bulbasaur::Bulbasaur(const Bulbasaur &source) : Pokemon(source)
 		factor[i] = source.factor[i];
 	}
 	type = source.type;
-}
-
-// destructor
-Bulbasaur::~Bulbasaur()
-{
-	delete[] factor;
-	factor = NULL;
 }
 
 // display Bulbasaur's name

--- a/redblacktree.cpp
+++ b/redblacktree.cpp
@@ -94,91 +94,10 @@ int RedBlackTree::height(Pokemon *ptr)
 		return rheight + 1;
 }
 
-// display tree by breadth
-void RedBlackTree::displayBreadth()
-{
-	int h = height(root);
-	for (int i = 1; i <= h; ++i)
-	{
-		cout << "Level " << i << ":  ";
-		displayBreadth(root, i);
-		cout << endl;
-	}
-}
-
-// recursively display tree by breadth
-void RedBlackTree::displayBreadth(Pokemon *ptr, int level)
-{
-	if (!ptr)
-		return;
-
-	if (level == 1)
-	{
-		cout << *ptr << ", colors are: " << ptr->leftColor() << "/" << ptr->rightColor() << "\t";
-	}
-	else
-	{
-		displayBreadth(ptr->leftLink(), level - 1);
-		displayBreadth(ptr->rightLink(), level - 1);
-	}
-}
-
 // insert pokemon pointer
 int RedBlackTree::insert(Pokemon *pokemon)
 {
 	return insert(root, pokemon);
-}
-
-// insert pokemon by type indication
-int RedBlackTree::insert(string type, AddOnsDb *database, string name)
-{
-	Pokemon *toAdd = NULL;
-	if (type == "Pikachu")
-	{
-		if (name != "")
-		{
-			toAdd = new Pikachu(database, name);
-		}
-		else
-		{
-			toAdd = new Pikachu(database);
-		}
-	}
-	if (type == "Charmander")
-	{
-		if (name != "")
-		{
-			toAdd = new Charmander(database, name);
-		}
-		else
-		{
-			toAdd = new Charmander(database);
-		}
-	}
-	if (type == "Squirtle")
-	{
-		if (name != "")
-		{
-			toAdd = new Squirtle(database, name);
-		}
-		else
-		{
-			toAdd = new Squirtle(database);
-		}
-	}
-	if (type == "Bulbasaur")
-	{
-		if (name != "")
-		{
-			toAdd = new Bulbasaur(database, name);
-		}
-		else
-		{
-			toAdd = new Bulbasaur(database);
-		}
-	}
-	toAdd->initialize();
-	return insert(root, toAdd);
 }
 
 // insert pokemon recursively and maintain properties of a redblack tree
@@ -324,25 +243,6 @@ void RedBlackTree::displayInorder(Pokemon *ptr, int &count)
 	ptr->displayFullInfo();
 	cout << endl;
 	displayInorder(ptr->rightLink(), count);
-}
-
-// display preorder
-void RedBlackTree::displayPreorder()
-{
-	displayPreorder(root);
-	cout << endl;
-}
-
-// display preorder
-void RedBlackTree::displayPreorder(Pokemon *ptr)
-{
-	if (!ptr)
-		return;
-
-	ptr->displayFullInfo();
-	cout << endl;
-	displayPreorder(ptr->leftLink());
-	displayPreorder(ptr->rightLink());
 }
 
 // destroy tree

--- a/redblacktree.h
+++ b/redblacktree.h
@@ -26,9 +26,7 @@ private:
 
 	void copy(Pokemon *&, Pokemon *);				// copy from one tree to another
 	int height(Pokemon *);							// find height of the tree
-	void displayBreadth(Pokemon *, int);			// display by breadth of the tree
 	void displayInorder(Pokemon *, int &);			// display by inorder
-	void displayPreorder(Pokemon *);				// display by preorder
 	int insert(Pokemon *&, Pokemon *);				// recursively insert a new pokemon
 	Pokemon *rightRotate(Pokemon *&, Pokemon *&);	// rotate right for rebalance
 	Pokemon *leftRotate(Pokemon *&, Pokemon *&);	// rotate left for rebalace
@@ -43,17 +41,14 @@ public:
 	RedBlackTree(const RedBlackTree &); // copy constructor
 	~RedBlackTree();					// destructor
 
-	bool isEmpty() const;						 // indicate if tree is empty or not
-	int height();								 // find height helper function
-	void displayBreadth();						 // display by breadth helper function
-	int displayInorder();						 // display by inorder helper function
-	void displayPreorder();						 // display by preorder helper functon
-	int insert(string, AddOnsDb *, string = ""); // insert into tree by type indication only
-	int insert(Pokemon *);						 // insert into tree with created pokemon
-	Pokemon *retrieve(const string &);			 // retrieve pokemon by name
-	Pokemon *choose(const char *);				 // select a pokemon with prompt
-	int showGrown();							 // show grown helper function
-	void restore();								 // restore helper function
+	bool isEmpty() const;			   // indicate if tree is empty or not
+	int height();					   // find height helper function
+	int displayInorder();			   // display by inorder helper function
+	int insert(Pokemon *);			   // insert into tree with created pokemon
+	Pokemon *retrieve(const string &); // retrieve pokemon by name
+	Pokemon *choose(const char *);	   // select a pokemon with prompt
+	int showGrown();				   // show grown helper function
+	void restore();					   // restore helper function
 
 	RedBlackTree &operator=(const RedBlackTree &); //= operator overload
 };


### PR DESCRIPTION
Combined similar things in subclass pokemons into parent class pokemon.  

Reason:  The sub pokemon classes were very similar (their hit functions were the exact same).  Moving to the parent class follows OOP and better differentiates the sub classes.