### PR TITLE
Redblacktreenode

### DIFF
--- a/addons.h
+++ b/addons.h
@@ -30,6 +30,7 @@ protected:
 
 public:
 	AddOns();
+	// ~AddOns();
 
 	virtual void display(ostream &) const = 0;
 	virtual int use() = 0;

--- a/kanto.cpp
+++ b/kanto.cpp
@@ -179,7 +179,7 @@ void Kanto::searchItem()
 
 void Kanto::foundItem()
 {
-	Items *newItem = new Items(*(dynamic_cast<Items *>(database.retrieveItem())));
+	Items *newItem = dynamic_cast<Items *>(database.retrieveItem());
 	cout << "\nYou found a " << *newItem << endl;
 
 	char answer = minalib::getYesNo("Do you want to give it to a Pokemon? (y/n) ");
@@ -187,20 +187,18 @@ void Kanto::foundItem()
 	if (toupper(answer) == 'N')
 	{
 		cout << "\nYou lost the item!\n\n";
-		delete newItem;
 		return;
 	}
 	if (backpack.isEmpty())
 	{
 		cout << "You have no Pokemon to hold this item! You lost the item!\n\n";
-		delete newItem;
 		return;
 	}
 
 	giveItemToPokemon(newItem);
 }
 
-void Kanto::giveItemToPokemon(Items *&newItem)
+void Kanto::giveItemToPokemon(Items *newItem)
 {
 	RedBlackTreeNode* node {nullptr};
 	Pokemon *chosen{nullptr};
@@ -223,7 +221,6 @@ void Kanto::giveItemToPokemon(Items *&newItem)
 		if (toupper(userInput) == 'N')
 		{
 			cout << "\nYou lost the item!\n\n";
-			delete newItem;
 			return;
 		}
 	} while (toupper(userInput) == 'Y');

--- a/kanto.cpp
+++ b/kanto.cpp
@@ -202,11 +202,13 @@ void Kanto::foundItem()
 
 void Kanto::giveItemToPokemon(Items *&newItem)
 {
+	RedBlackTreeNode* node {nullptr};
 	Pokemon *chosen{nullptr};
 	char userInput{'\0'};
 	do
 	{
-		chosen = backpack.choose("Select a Pokemon to hold item: ");
+		node = backpack.choose("Select a Pokemon to hold item: ");
+		chosen = dynamic_cast<Pokemon *>(node);
 		cout << endl;
 		if (!(chosen->isHoldingItem()))
 		{
@@ -265,12 +267,16 @@ void Kanto::battleSimulation()
 
 void Kanto::choosePokemonsForBattle(Pokemon *&pokemon1, Pokemon *&pokemon2)
 {
-	pokemon1 = backpack.choose("Select your 1st Pokemon for battle simulation: ");
-	pokemon2 = backpack.choose("Select your 2nd Pokemon for battle simulation: ");
+	RedBlackTreeNode* node1, *node2;
+	node1 = backpack.choose("Select your 1st Pokemon for battle simulation: ");
+	node2 = backpack.choose("Select your 2nd Pokemon for battle simulation: ");
+	pokemon1 = dynamic_cast<Pokemon *>(node1);
+	pokemon2 = dynamic_cast<Pokemon *>(node2);
 	while (pokemon1 == pokemon2)
 	{
-		pokemon2 = backpack.choose("A Pokemon can't battle itself."
+		node2 = backpack.choose("A Pokemon can't battle itself."
 								   "\nSelect a 2nd Pokemon for battle simulation: ");
+		pokemon2 = dynamic_cast<Pokemon *>(node2);
 	}
 }
 

--- a/kanto.h
+++ b/kanto.h
@@ -33,7 +33,7 @@ private:
 	void renamePokemon(Pokemon *&);
 	void foundItem();
 	Pokemon *drawPokemonType();
-	void giveItemToPokemon(Items *&item);
+	void giveItemToPokemon(Items *item);
 	void displayBigAnnouncement(const string = ""); // output an announcement
 	void choosePokemonsForBattle(Pokemon *&pokemon1, Pokemon *&pokemon2);
 	void battle(Pokemon &pokemon1, Pokemon &pokemon2); // pokemon battle!

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ kanto.o: kanto.h kanto.cpp
 redblacktree.o: redblacktree.h redblacktree.cpp
 	g++ -g -c redblacktree.cpp
 
-pokemon.o: pokemon.h pokemonabc.cpp pokemonsub.cpp
+pokemon.o: pokemonabc.h pokemonsub.h pokemonabc.cpp pokemonsub.cpp
 	g++ -g -c pokemonabc.cpp pokemonsub.cpp
 
 addonsdb.o: addonsdb.h addonsdb.cpp

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-a.out: main.o minalib.o addons.o addonsdb.o pokemon.o redblacktree.o kanto.o
+a.out: main.o minalib.o addons.o addonsdb.o redblacktreenode.o pokemon.o redblacktree.o kanto.o
 	g++ -g *.o
 
 main.o: main.cpp
@@ -12,6 +12,9 @@ redblacktree.o: redblacktree.h redblacktree.cpp
 
 pokemon.o: pokemonabc.h pokemonsub.h pokemonabc.cpp pokemonsub.cpp
 	g++ -g -c pokemonabc.cpp pokemonsub.cpp
+
+redblacktreenode.o: redblacktreenode.h redblacktreenode.cpp
+	g++ -g -c redblacktreenode.cpp
 
 addonsdb.o: addonsdb.h addonsdb.cpp
 	g++ -g -c addonsdb.cpp

--- a/pokemonabc.cpp
+++ b/pokemonabc.cpp
@@ -12,6 +12,8 @@ This file contains the implementations for class Pokemon.  Pokemon is an ABC.
 
 RedBlackTreeNode::RedBlackTreeNode() : lcolor(BLACK), rcolor(BLACK), left(0), right(0) {}
 
+RedBlackTreeNode::~RedBlackTreeNode() {}
+
 // return color of left child
 bool &RedBlackTreeNode::leftColor()
 {

--- a/pokemonabc.cpp
+++ b/pokemonabc.cpp
@@ -8,7 +8,7 @@ Term:	    Fall 2020
 This file contains the implementations for class Pokemon.  Pokemon is an ABC.
 */
 
-#include "pokemon.h"
+#include "pokemonabc.h"
 
 // default constructor
 Pokemon::Pokemon() : type(normal), status(alive), grown(0), level(0), exp(0), hp(0), maxHP(0), factor(0), database(0), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)

--- a/pokemonabc.cpp
+++ b/pokemonabc.cpp
@@ -10,34 +10,6 @@ This file contains the implementations for class Pokemon.  Pokemon is an ABC.
 
 #include "pokemonabc.h"
 
-RedBlackTreeNode::RedBlackTreeNode() : lcolor(BLACK), rcolor(BLACK), left(0), right(0) {}
-
-RedBlackTreeNode::~RedBlackTreeNode() {}
-
-// return color of left child
-bool &RedBlackTreeNode::leftColor()
-{
-	return lcolor;
-}
-
-// return color of right child
-bool &RedBlackTreeNode::rightColor()
-{
-	return rcolor;
-}
-
-// connect with left child in RB tree
-RedBlackTreeNode *&RedBlackTreeNode::leftLink()
-{
-	return left;
-}
-
-// connect with right child in RB tree
-RedBlackTreeNode *&RedBlackTreeNode::rightLink()
-{
-	return right;
-}
-
 // default constructor
 Pokemon::Pokemon() : type(normal), status(alive), grown(0), level(0), exp(0), hp(0), maxHP(0), factor(0), database(0), moves(0)
 {

--- a/pokemonabc.cpp
+++ b/pokemonabc.cpp
@@ -85,7 +85,9 @@ void Pokemon::copy(AddOns **source)
 void Pokemon::destroyMovesList()
 {
 	for (int i{0}; i < MAX_MOVES; ++i)
-		delete moves[i];
+		if (moves[i]) {
+			delete moves[i];
+		}
 }
 
 // display moves set helper function

--- a/pokemonabc.cpp
+++ b/pokemonabc.cpp
@@ -10,8 +10,34 @@ This file contains the implementations for class Pokemon.  Pokemon is an ABC.
 
 #include "pokemonabc.h"
 
+RedBlackTreeNode::RedBlackTreeNode() : lcolor(BLACK), rcolor(BLACK), left(0), right(0) {}
+
+// return color of left child
+bool &RedBlackTreeNode::leftColor()
+{
+	return lcolor;
+}
+
+// return color of right child
+bool &RedBlackTreeNode::rightColor()
+{
+	return rcolor;
+}
+
+// connect with left child in RB tree
+RedBlackTreeNode *&RedBlackTreeNode::leftLink()
+{
+	return left;
+}
+
+// connect with right child in RB tree
+RedBlackTreeNode *&RedBlackTreeNode::rightLink()
+{
+	return right;
+}
+
 // default constructor
-Pokemon::Pokemon() : type(normal), status(alive), grown(0), level(0), exp(0), hp(0), maxHP(0), factor(0), database(0), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)
+Pokemon::Pokemon() : type(normal), status(alive), grown(0), level(0), exp(0), hp(0), maxHP(0), factor(0), database(0), moves(0)
 {
 	moves = new AddOns *[MAX_MOVES];
 	for (int i{0}; i < MAX_MOVES; ++i)
@@ -19,7 +45,7 @@ Pokemon::Pokemon() : type(normal), status(alive), grown(0), level(0), exp(0), hp
 }
 
 // copy constructor
-Pokemon::Pokemon(const Pokemon &source) : type(source.type), status(source.status), grown(source.grown), level(source.level), exp(source.exp), hp(source.hp), maxHP(source.maxHP), factor(0), name(source.name), database(source.database), moves(0), lcolor(BLACK), rcolor(BLACK), left(0), right(0)
+Pokemon::Pokemon(const Pokemon &source) : RedBlackTreeNode(), type(source.type), status(source.status), grown(source.grown), level(source.level), exp(source.exp), hp(source.hp), maxHP(source.maxHP), factor(0), name(source.name), database(source.database), moves(0)
 {
 	factor = new float[TYPES];
 	for (int i = 0; i < TYPES; ++i)
@@ -470,28 +496,4 @@ bool operator>(const Pokemon &str1, const string &str2)
 bool operator>(const string &str1, const Pokemon &str2)
 {
 	return str1 > str2.name;
-}
-
-// connect with left child in RB tree
-Pokemon *&Pokemon::leftLink()
-{
-	return left;
-}
-
-// connect with right child in RB tree
-Pokemon *&Pokemon::rightLink()
-{
-	return right;
-}
-
-// return color of left child
-bool &Pokemon::leftColor()
-{
-	return lcolor;
-}
-
-// return color of right child
-bool &Pokemon::rightColor()
-{
-	return rcolor;
 }

--- a/pokemonabc.h
+++ b/pokemonabc.h
@@ -1,7 +1,7 @@
 /*
 Programmer: Mina Vu
 Assignment: Prog3
-File name:  pokemon.h
+File name:  pokemonabc.h
 Class:      CS202
 Term:	    Fall 2020
 
@@ -10,8 +10,8 @@ Pikachu, Charmander, Squirtle, and Bulbasaur.  Each Pokemon derived classes take
 a pointer to the attacks/items database to populate their moves set.
 */
 
-#ifndef POKEMON_H
-#define POKEMON_H
+#ifndef POKEMONABC_H
+#define POKEMONABC_H
 
 #include <iostream>
 #include "addonsdb.h"
@@ -120,46 +120,6 @@ public:
 
 	friend ostream &operator<<(ostream &, const Pokemon &); // overload << operator
 	friend istream &operator>>(istream &, Pokemon &);		// overload << operator
-};
-
-class Pikachu : public Pokemon
-{
-public:
-	Pikachu();										  // default constructor
-	Pikachu(const Pikachu &);						  // copy constructor
-	Pikachu &operator=(Pikachu &); // overload = operator
-
-	void displayFullInfo() const;  // display all info
-};
-
-class Charmander : public Pokemon
-{
-public:
-	Charmander();											// default constructor
-	Charmander(const Charmander &);							// copy constructor
-	Charmander &operator=(Charmander &); // overload = operator
-
-	void displayFullInfo() const;  // display all info
-};
-
-class Squirtle : public Pokemon
-{
-public:
-	Squirtle();											// default constructor
-	Squirtle(const Squirtle &);							// copy constructor
-	Squirtle &operator=(Squirtle &); // overload = operator
-
-	void displayFullInfo() const;  // display all info
-};
-
-class Bulbasaur : public Pokemon
-{
-public:
-	Bulbasaur();										  // default constructor
-	Bulbasaur(const Bulbasaur &);						  // copy constructor
-	Bulbasaur &operator=(Bulbasaur &); // overload = operator
-
-	void displayFullInfo() const;  // display all info
 };
 
 #endif

--- a/pokemonabc.h
+++ b/pokemonabc.h
@@ -32,9 +32,10 @@ class RedBlackTreeNode {
 
 	public:
 		RedBlackTreeNode();
+		virtual ~RedBlackTreeNode();
 
-		virtual bool &leftColor();	   // return left color for redblack tree
-		virtual bool &rightColor();	   // return right color for redblack tree
+		bool &leftColor();	   // return left color for redblack tree
+		bool &rightColor();	   // return right color for redblack tree
 		RedBlackTreeNode *&leftLink();  // return left pointer
 		RedBlackTreeNode *&rightLink(); // return right pointer
 
@@ -81,7 +82,7 @@ protected:
 public:
 	Pokemon();					 // default constructor
 	Pokemon(const Pokemon &);	 // copy constructor
-	virtual ~Pokemon() = 0;			 // destructor
+	~Pokemon() = 0;			 // destructor
 
 	virtual void displayFullInfo() const;	   // display all info
 	bool hit(const Attacks &);	   // take a hit from the opponent

--- a/pokemonabc.h
+++ b/pokemonabc.h
@@ -18,7 +18,29 @@ a pointer to the attacks/items database to populate their moves set.
 
 using namespace std;
 
-class Pokemon
+class RedBlackTreeNode {
+	protected:
+		enum
+		{
+			BLACK,
+			RED
+		};
+		bool lcolor;
+		bool rcolor;
+		RedBlackTreeNode *left;
+		RedBlackTreeNode *right;
+
+	public:
+		RedBlackTreeNode();
+
+		virtual bool &leftColor();	   // return left color for redblack tree
+		virtual bool &rightColor();	   // return right color for redblack tree
+		RedBlackTreeNode *&leftLink();  // return left pointer
+		RedBlackTreeNode *&rightLink(); // return right pointer
+
+};
+
+class Pokemon : public RedBlackTreeNode
 {
 private:
 	void copy(AddOns **source);			// copy array recursion for moves array
@@ -56,16 +78,6 @@ protected:
 	float *factor;
 	AddOns **moves;
 
-	enum
-	{
-		BLACK,
-		RED
-	};
-	bool lcolor;
-	bool rcolor;
-	Pokemon *left;
-	Pokemon *right;
-
 public:
 	Pokemon();					 // default constructor
 	Pokemon(const Pokemon &);	 // copy constructor
@@ -86,11 +98,6 @@ public:
 	bool isAlive();					 // return status for battle
 
 	void displayBattleStats() const; // display only name, level, hp
-
-	Pokemon *&leftLink();  // return left pointer
-	Pokemon *&rightLink(); // return right pointer
-	bool &leftColor();	   // return left color for redblack tree
-	bool &rightColor();	   // return right color for redblack tree
 
 	Pokemon &operator=(Pokemon &);		//= operator overload
 	Pokemon &operator+=(const Items &); //+= operator overload to hold item

--- a/pokemonabc.h
+++ b/pokemonabc.h
@@ -5,41 +5,16 @@ File name:  pokemonabc.h
 Class:      CS202
 Term:	    Fall 2020
 
-This is the header file for abstract base class Pokemon and its derived classes
-Pikachu, Charmander, Squirtle, and Bulbasaur.  Each Pokemon derived classes takes
-a pointer to the attacks/items database to populate their moves set.
+This is the header file for abstract base class Pokemon.
 */
 
 #ifndef POKEMONABC_H
 #define POKEMONABC_H
 
 #include <iostream>
-#include "addonsdb.h"
+#include "redblacktreenode.h"
 
 using namespace std;
-
-class RedBlackTreeNode {
-	protected:
-		enum
-		{
-			BLACK,
-			RED
-		};
-		bool lcolor;
-		bool rcolor;
-		RedBlackTreeNode *left;
-		RedBlackTreeNode *right;
-
-	public:
-		RedBlackTreeNode();
-		virtual ~RedBlackTreeNode();
-
-		bool &leftColor();	   // return left color for redblack tree
-		bool &rightColor();	   // return right color for redblack tree
-		RedBlackTreeNode *&leftLink();  // return left pointer
-		RedBlackTreeNode *&rightLink(); // return right pointer
-
-};
 
 class Pokemon : public RedBlackTreeNode
 {

--- a/pokemonsub.cpp
+++ b/pokemonsub.cpp
@@ -9,7 +9,7 @@ This file contains the implementations for classes Pikachu, Charmander,
 Squirtle, and Bulbasaur.
 */
 
-#include "pokemon.h"
+#include "pokemonsub.h"
 
 // default constructor
 Pikachu::Pikachu()

--- a/pokemonsub.h
+++ b/pokemonsub.h
@@ -1,0 +1,61 @@
+/*
+Programmer: Mina Vu
+Assignment: Prog3
+File name:  pokemonsub.h
+Class:      CS202
+Term:	    Fall 2020
+
+This is the header file for abstract base class Pokemon and its derived classes
+Pikachu, Charmander, Squirtle, and Bulbasaur.  Each Pokemon derived classes takes
+a pointer to the attacks/items database to populate their moves set.
+*/
+
+#ifndef POKEMONSUB_H
+#define POKEMONSUB_H
+
+#include <iostream>
+#include "pokemonabc.h"
+
+using namespace std;
+
+class Pikachu : public Pokemon
+{
+public:
+	Pikachu();										  // default constructor
+	Pikachu(const Pikachu &);						  // copy constructor
+	Pikachu &operator=(Pikachu &); // overload = operator
+
+	void displayFullInfo() const;  // display all info
+};
+
+class Charmander : public Pokemon
+{
+public:
+	Charmander();											// default constructor
+	Charmander(const Charmander &);							// copy constructor
+	Charmander &operator=(Charmander &); // overload = operator
+
+	void displayFullInfo() const;  // display all info
+};
+
+class Squirtle : public Pokemon
+{
+public:
+	Squirtle();											// default constructor
+	Squirtle(const Squirtle &);							// copy constructor
+	Squirtle &operator=(Squirtle &); // overload = operator
+
+	void displayFullInfo() const;  // display all info
+};
+
+class Bulbasaur : public Pokemon
+{
+public:
+	Bulbasaur();										  // default constructor
+	Bulbasaur(const Bulbasaur &);						  // copy constructor
+	Bulbasaur &operator=(Bulbasaur &); // overload = operator
+
+	void displayFullInfo() const;  // display all info
+};
+
+#endif

--- a/redblacktree.h
+++ b/redblacktree.h
@@ -22,19 +22,19 @@ private:
 		BLACK,
 		RED
 	};
-	Pokemon *root;
+	RedBlackTreeNode *root;
 
-	void copy(Pokemon *&, Pokemon *);				// copy from one tree to another
-	int height(Pokemon *);							// find height of the tree
-	void displayInorder(Pokemon *, int &);			// display by inorder
-	int insert(Pokemon *&, Pokemon *);				// recursively insert a new pokemon
-	Pokemon *rightRotate(Pokemon *&, Pokemon *&);	// rotate right for rebalance
-	Pokemon *leftRotate(Pokemon *&, Pokemon *&);	// rotate left for rebalace
-	void destroy(Pokemon *&);						// destroy tree
-	Pokemon *retrieve(Pokemon *, const string &);	// retrieve a pokemon from the tree by name
-	void choose(Pokemon *, Pokemon *&, int, int &); // select a pokemon form the tree by number
-	int showGrown(Pokemon *);						// find all pokemons that have leveled up
-	void restore(Pokemon *);						// restore all pokemons
+	void copy(RedBlackTreeNode *&, RedBlackTreeNode *);				// copy from one tree to another
+	int height(RedBlackTreeNode *);							// find height of the tree
+	void displayInorder(RedBlackTreeNode *, int &);			// display by inorder
+	int insert(RedBlackTreeNode *&, RedBlackTreeNode *);				// recursively insert a new pokemon
+	RedBlackTreeNode *rightRotate(RedBlackTreeNode *&, RedBlackTreeNode *&);	// rotate right for rebalance
+	RedBlackTreeNode *leftRotate(RedBlackTreeNode *&, RedBlackTreeNode *&);	// rotate left for rebalace
+	void destroy(RedBlackTreeNode *&);						// destroy tree
+	RedBlackTreeNode *retrieve(RedBlackTreeNode *, const string &);	// retrieve a pokemon from the tree by name
+	void choose(RedBlackTreeNode *, RedBlackTreeNode *&, int, int &); // select a pokemon form the tree by number
+	int showGrown(RedBlackTreeNode *);						// find all pokemons that have leveled up
+	void restore(RedBlackTreeNode *);						// restore all pokemons
 
 public:
 	RedBlackTree();						// default constructor
@@ -44,9 +44,9 @@ public:
 	bool isEmpty() const;			   // indicate if tree is empty or not
 	int height();					   // find height helper function
 	int displayInorder();			   // display by inorder helper function
-	int insert(Pokemon *);			   // insert into tree with created pokemon
-	Pokemon *retrieve(const string &); // retrieve pokemon by name
-	Pokemon *choose(const char *);	   // select a pokemon with prompt
+	int insert(RedBlackTreeNode *);			   // insert into tree with created pokemon
+	RedBlackTreeNode *retrieve(const string &); // retrieve pokemon by name
+	RedBlackTreeNode *choose(const char *);	   // select a pokemon with prompt
 	int showGrown();				   // show grown helper function
 	void restore();					   // restore helper function
 

--- a/redblacktree.h
+++ b/redblacktree.h
@@ -12,7 +12,7 @@ RedBlackTree class is the data structure for the assignment.
 #ifndef REDBLACKTREE_H
 #define REDBLACKTREE_H
 
-#include "pokemon.h"
+#include "pokemonsub.h"
 
 class RedBlackTree
 {

--- a/redblacktreenode.cpp
+++ b/redblacktreenode.cpp
@@ -1,0 +1,39 @@
+/*
+Programmer: Mina Vu
+Assignment: Prog3
+File name:  redblacktreenode.cpp
+Class:      CS202
+Term:	    Fall 2020
+
+This file contains the implementations for class RedBlackTreeNode.
+*/
+
+#include "redblacktreenode.h"
+
+RedBlackTreeNode::RedBlackTreeNode() : lcolor(BLACK), rcolor(BLACK), left(0), right(0) {}
+
+RedBlackTreeNode::~RedBlackTreeNode() {}
+
+// return color of left child
+bool &RedBlackTreeNode::leftColor()
+{
+	return lcolor;
+}
+
+// return color of right child
+bool &RedBlackTreeNode::rightColor()
+{
+	return rcolor;
+}
+
+// connect with left child in RB tree
+RedBlackTreeNode *&RedBlackTreeNode::leftLink()
+{
+	return left;
+}
+
+// connect with right child in RB tree
+RedBlackTreeNode *&RedBlackTreeNode::rightLink()
+{
+	return right;
+}

--- a/redblacktreenode.h
+++ b/redblacktreenode.h
@@ -1,0 +1,42 @@
+/*
+Programmer: Mina Vu
+Assignment: Prog3
+File name:  redblacktreenode.h
+Class:      CS202
+Term:	    Fall 2020
+
+This is the header file for the class RedBlackTreeNode.
+*/
+
+#ifndef REDBLACKTREENODE_H
+#define REDBLACKTREENODE_H
+
+#include <iostream>
+#include "addonsdb.h"
+
+using namespace std;
+
+class RedBlackTreeNode {
+	protected:
+		enum
+		{
+			BLACK,
+			RED
+		};
+		bool lcolor;
+		bool rcolor;
+		RedBlackTreeNode *left;
+		RedBlackTreeNode *right;
+
+	public:
+		RedBlackTreeNode();
+		virtual ~RedBlackTreeNode();
+
+		bool &leftColor();	   // return left color for redblack tree
+		bool &rightColor();	   // return right color for redblack tree
+		RedBlackTreeNode *&leftLink();  // return left pointer
+		RedBlackTreeNode *&rightLink(); // return right pointer
+
+};
+
+#endif


### PR DESCRIPTION
Moved redblacktree attributes out of pokemon class into its own node class.

Reason:  This keeps each class to adhere to SRP, and it shortens the Pokemon class a bit.  The downside is that I had to do a lot of downcasting for the other functionalities to work.